### PR TITLE
Use a separate post type for scheduled revisions

### DIFF
--- a/revisions-extended/includes/post-type.php
+++ b/revisions-extended/includes/post-type.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace RevisionsExtended\Post_Type;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_action( 'init', __NAMESPACE__ . '\register' );
+
+/**
+ * Register post types.
+ *
+ * @return void
+ */
+function register() {
+	$labels = array(
+		'name'          => __( 'Scheduled Updates', 'revisions-extended' ),
+		'singular_name' => __( 'Scheduled Update', 'revisions-extended' ),
+	);
+
+	register_post_type(
+		'revex_revision',
+		array(
+			'label'             => __( 'Scheduled Updates', 'revisions-extended' ),
+			'labels'            => $labels,
+			'public'            => false,
+			'show_ui'           => true,
+			'show_in_menu'      => true,
+			'show_in_nav_menus' => false,
+			'show_in_admin_bar' => false,
+			'show_in_rest'      => true,
+			'menu_position'     => 50,
+			'menu_icon'         => 'dashicons-backup',
+			'supports'          => array( 'title', 'editor', 'excerpt', 'author' ),
+		)
+	);
+}

--- a/revisions-extended/index.php
+++ b/revisions-extended/index.php
@@ -34,6 +34,7 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\initialize_rest_routes', 100 );
 function load_files() {
 	require_once get_includes_path() . 'capabilities.php';
 	require_once get_includes_path() . 'post-status.php';
+	require_once get_includes_path() . 'post-type.php';
 	require_once get_includes_path() . 'rest-revisions-controller.php';
 	require_once get_includes_path() . 'revision.php';
 	require_once get_includes_path() . 'block-editor-modifier.php';


### PR DESCRIPTION
Instead of trying to extend WP's built in revision system, this creates a separate post type for storing scheduled revisions.