### PR TITLE
Switch techniques to use a shadow button.

### DIFF
--- a/revisions-extended/src/components/confirm-window/index.js
+++ b/revisions-extended/src/components/confirm-window/index.js
@@ -7,12 +7,12 @@ import { Modal, __experimentalText as Text } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { useInterface, usePost } from '../../hooks';
+import { usePost } from '../../hooks';
+import { clearLocalChanges } from '../../utils';
 import './index.css';
 
 const ConfirmWindow = ( { title, notice, links } ) => {
 	const { savedPost } = usePost();
-	const { clearLocalChanges } = useInterface();
 
 	const onLeave = ( e ) => {
 		e.preventDefault();

--- a/revisions-extended/src/hooks/interface.js
+++ b/revisions-extended/src/hooks/interface.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { dispatch } from '@wordpress/data';
 import {
 	createContext,
 	useContext,
@@ -10,85 +9,125 @@ import {
 } from '@wordpress/element';
 
 /**
- * Internal dependencies
+ * Module variables
  */
-import { usePost } from './post';
-import { GUTENBERG_EDITOR_STORE } from '../settings';
+const OUR_BUTTON_ID = 'revisions-extended-button';
 
-const PROP_BTN_TEXT = 'btnText';
-const PROP_FN_SAVE = 'savePost';
-
-const getStashProp = ( prop ) => {
-	return window.revisionPluginStash
-		? window.revisionPluginStash[ prop ]
-		: undefined;
-};
-
-const stashGutenbergData = ( data ) => {
-	window.revisionPluginStash = {
-		...window.revisionPluginStash,
-		...data,
-	};
-};
-
-const setSavePostFunction = ( fn ) => {
-	dispatch( GUTENBERG_EDITOR_STORE ).savePost = fn;
-};
-
-const getBtnElement = () => {
+const getGutenbergButtonElement = () => {
 	return document.querySelector( '.editor-post-publish-button__button' );
 };
 
-const setBtnText = ( text ) => {
-	const btn = getBtnElement();
-	if ( btn && text ) {
-		btn.innerText = text;
-	}
+const getOurButtonElement = () => {
+	return document.getElementById( OUR_BUTTON_ID );
 };
 
-const clearLocalChanges = ( id ) => {
-	// There's gotta be a better approach
-	window.sessionStorage.removeItem( `wp-autosave-block-editor-post-${ id }` );
+const showElement = ( el ) => ( el.style.display = 'block' );
+const hideElement = ( el ) => ( el.style.display = 'none' );
+
+/**
+ * Insert an html element to the right
+ *
+ * @param {HTMLElement} btnDomRef The gutenberg button dom reference
+ * @param {HTMLElement} newNode Element to be added
+ */
+const insertButton = ( btnDomRef, newNode ) => {
+	try {
+		btnDomRef.parentElement.removeChild( newNode );
+	} catch ( ex ) {}
+
+	btnDomRef.parentElement.insertBefore( newNode, btnDomRef.nextSibling );
+};
+
+/**
+ * Clones the button and updates its properties
+ *
+ * @param {HTMLElement} btnDomRef The gutenberg button dom reference
+ * @param {Object} param
+ * @param {string} param.text
+ * @param {Function} param.callback
+ */
+const cloneButton = ( btnDomRef, { text, callback } ) => {
+	const newNode = btnDomRef.cloneNode();
+
+	// Update some of the cloned properties
+	newNode.id = OUR_BUTTON_ID;
+	newNode.innerText = text ? text : btnDomRef.innerText;
+	newNode.setAttribute( 'aria-disabled', false );
+	newNode.addEventListener( 'click', callback );
+
+	// It will copy its hidden-ness
+	showElement( newNode );
+
+	return newNode;
+};
+
+/**
+ * Removes itself from the DOM
+ *
+ * @param {HTMLElement} domNode HTML node to remove
+ */
+const removeBtn = ( domNode ) => {
+	try {
+		domNode.parentElement.removeChild( domNode );
+	} catch ( ex ) {}
+};
+
+/**
+ * Turns on our button and turns off Gutenberg's button
+ *
+ * @param {HTMLElement} gutenbergBtn The gutenberg button dom reference
+ * @param {Object} btnState
+ */
+const toggleBtnOn = ( gutenbergBtn, btnState ) => {
+	const newNode = cloneButton( gutenbergBtn, btnState );
+	insertButton( gutenbergBtn, newNode );
+
+	// Hide the gutenberg btn
+	hideElement( gutenbergBtn );
+};
+
+/**
+ * Turns off our button and turns on Gutenberg's button
+ *
+ * @param {HTMLElement} gutenbergBtn The gutenberg button dom reference
+ */
+const toggleBtnOff = ( gutenbergBtn ) => {
+	// Remove our button
+	removeBtn( getOurButtonElement() );
+
+	// Show the Gutenberg button
+	showElement( gutenbergBtn );
 };
 
 const StateContext = createContext();
 
-export function InterfaceProvider( { children, btnTextOnLoad = false } ) {
-	const [ shouldIntercept, setShouldIntercept ] = useState( false );
-	const { isSavingPost, savedPost } = usePost();
+export function InterfaceProvider( { children, btnText = false } ) {
+	const [ shouldIntercept, setIntercept ] = useState( false );
+	const [ gutenbergBtn, setGutenbergBtn ] = useState( false );
+	const [ btnState, setBtnDefaults ] = useState( {
+		text: btnText,
+		callback: () => {},
+	} );
 
 	useEffect( () => {
-		if ( btnTextOnLoad ) {
-			setBtnText( btnTextOnLoad );
-		}
+		setGutenbergBtn( getGutenbergButtonElement() );
 	}, [] );
-
-	useEffect( () => {
-		if ( ! getStashProp( PROP_FN_SAVE ) ) {
-			stashGutenbergData( {
-				savePost: dispatch( GUTENBERG_EDITOR_STORE ).savePost,
-			} );
-		}
-
-		const btnRef = getBtnElement();
-
-		if ( btnRef && ! getStashProp( PROP_BTN_TEXT ) && ! isSavingPost ) {
-			stashGutenbergData( {
-				// The revision page sets the button on load since the Gutenberg one doesn't make sense.
-				btnText: btnTextOnLoad ? btnTextOnLoad : btnRef.innerText,
-			} );
-		}
-	}, [ savedPost ] );
 
 	return (
 		<StateContext.Provider
 			value={ {
-				setBtnText,
-				setSavePostFunction,
-				getStashProp,
+				setBtnDefaults: ( args ) => {
+					setBtnDefaults( { ...btnState, ...args } );
+				},
 				shouldIntercept,
-				setShouldIntercept,
-				clearLocalChanges,
+				setShouldIntercept: ( isChecked ) => {
+					if ( isChecked ) {
+						toggleBtnOn( gutenbergBtn, btnState );
+					} else {
+						toggleBtnOff( gutenbergBtn );
+					}
+					setIntercept( isChecked );
+				},
 			} }
 		>
 			{ children }

--- a/revisions-extended/src/hooks/post.js
+++ b/revisions-extended/src/hooks/post.js
@@ -29,12 +29,13 @@ export const usePost = () => {
 			isPublished: store.isCurrentPostPublished(),
 			isSavingPost: store.isSavingPost(),
 
-			changingToScheduled: store.isEditedPostBeingScheduled(),
+			changingToScheduled: store.isEditedPostBeingScheduled,
 			savedPost: store.getCurrentPost(),
-			content: store.getEditedPostContent(),
 			getEditedPostAttribute: store.getEditedPostAttribute,
 			getCurrentPostAttribute: store.getCurrentPostAttribute,
 			didPostSaveRequestSucceed: store.didPostSaveRequestSucceed,
+
+			savePost: dispatch( GUTENBERG_EDITOR_STORE ).savePost,
 			editPost: dispatch( GUTENBERG_EDITOR_STORE ).editPost,
 		};
 	}, [] );

--- a/revisions-extended/src/plugins/editor-modifications/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/index.js
@@ -1,6 +1,7 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 
 /**
@@ -21,7 +22,7 @@ const MainPlugin = () => {
 	}
 
 	return (
-		<InterfaceProvider>
+		<InterfaceProvider btnText={ __( 'Create update' ) }>
 			<UpdateButtonModifier />
 			<PluginPostStatusInfo />
 			<DocumentSettingsPanel />

--- a/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
@@ -23,33 +23,17 @@ import {
 	getAllRevisionUrl,
 } from '../../../utils';
 
-/**
- * Module constants
- */
-const PROP_BTN_TEXT = 'btnText';
-const PROP_FN_SAVE = 'savePost';
-
 const UpdateButtonModifier = () => {
 	const [ newRevision, setNewRevision ] = useState();
 	const { create } = useRevision();
-	const {
-		shouldIntercept,
-		setBtnText,
-		setSavePostFunction,
-		getStashProp,
-	} = useInterface();
+	const { setBtnDefaults } = useInterface();
 	const {
 		savedPost,
 		changingToScheduled,
-		isPublished,
 		getEditedPostAttribute,
 	} = usePost();
 
-	const _savePost = async ( gutenbergProps ) => {
-		if ( gutenbergProps && gutenbergProps.isAutosave ) {
-			return;
-		}
-
+	const _savePost = async () => {
 		const { data, error } = await create( {
 			postType: savedPost.type,
 			postId: savedPost.id,
@@ -57,7 +41,7 @@ const UpdateButtonModifier = () => {
 			title: getEditedPostAttribute( 'title' ),
 			excerpt: getEditedPostAttribute( 'excerpt' ),
 			content: getEditedPostAttribute( 'content' ),
-			changingToScheduled,
+			changingToScheduled: changingToScheduled(),
 		} );
 
 		if ( error ) {
@@ -73,22 +57,12 @@ const UpdateButtonModifier = () => {
 	};
 
 	useEffect( () => {
-		let btnText = getStashProp( PROP_BTN_TEXT );
-		let savePost = getStashProp( PROP_FN_SAVE );
-
-		if ( shouldIntercept ) {
-			btnText = __( 'Create Update' );
-			savePost = _savePost;
-		}
-
-		if ( btnText ) {
-			setBtnText( btnText );
-		}
-
-		if ( savePost ) {
-			setSavePostFunction( savePost );
-		}
-	}, [ isPublished, changingToScheduled, shouldIntercept ] );
+		setBtnDefaults( {
+			callback: async () => {
+				return await _savePost();
+			},
+		} );
+	}, [] );
 
 	if ( newRevision ) {
 		return (

--- a/revisions-extended/src/plugins/revision-editor/index.js
+++ b/revisions-extended/src/plugins/revision-editor/index.js
@@ -23,7 +23,7 @@ const PluginWrapper = () => {
 		window.location.href = getEditUrl( savedPost.parent );
 	}
 	return (
-		<InterfaceProvider btnTextOnLoad={ __( 'Update' ) }>
+		<InterfaceProvider btnText={ __( 'Update' ) }>
 			<UpdateButtonModifier />
 			<RevisionIndicator />
 			<TrashModifier />

--- a/revisions-extended/src/plugins/revision-editor/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/revision-editor/update-button-modifier/index.js
@@ -17,32 +17,14 @@ import { ConfirmWindow } from '../../../components';
 import { usePost, useRevision, useInterface } from '../../../hooks';
 import { getEditUrl, getAllRevisionUrl } from '../../../utils';
 
-/**
- * Module constants
- */
-const PROP_BTN_TEXT = 'btnText';
-const PROP_FN_SAVE = 'savePost';
-
 const UpdateButtonModifier = () => {
 	const [ showSuccess, setShowSuccess ] = useState( false );
-	const {
-		shouldIntercept,
-		setBtnText,
-		setSavePostFunction,
-		getStashProp,
-	} = useInterface();
-	const { savedPost, didPostSaveRequestSucceed } = usePost();
+	const { setBtnDefaults } = useInterface();
+	const { savedPost, didPostSaveRequestSucceed, savePost } = usePost();
 	const { publish } = useRevision();
 
-	const _savePost = async ( gutenbergProps ) => {
-		if ( gutenbergProps && gutenbergProps.isAutosave ) {
-			return;
-		}
-
+	const _savePost = async () => {
 		// Save the post first
-		// Grab the default Gutenberg function
-		const savePost = getStashProp( PROP_FN_SAVE );
-
 		await savePost();
 
 		if ( ! didPostSaveRequestSucceed() ) {
@@ -68,22 +50,12 @@ const UpdateButtonModifier = () => {
 	};
 
 	useEffect( () => {
-		let btnText = getStashProp( PROP_BTN_TEXT );
-		let savePost = getStashProp( PROP_FN_SAVE );
-
-		if ( shouldIntercept ) {
-			btnText = __( 'Publish' );
-			savePost = _savePost;
-		}
-
-		if ( btnText ) {
-			setBtnText( btnText );
-		}
-
-		if ( savePost ) {
-			setSavePostFunction( savePost );
-		}
-	}, [ shouldIntercept ] );
+		setBtnDefaults( {
+			callback: async () => {
+				return await _savePost();
+			},
+		} );
+	}, [] );
 
 	if ( showSuccess ) {
 		return (

--- a/revisions-extended/src/utils.js
+++ b/revisions-extended/src/utils.js
@@ -49,3 +49,8 @@ export const getStatusDisplay = ( postStatus, date ) => {
 	}
 	return '';
 };
+
+export const clearLocalChanges = ( id ) => {
+	// There's gotta be a better approach
+	window.sessionStorage.removeItem( `wp-autosave-block-editor-post-${ id }` );
+};


### PR DESCRIPTION
Addresses: #12 

This PR changes the approach to handling the way we save and publish revisions. 

Here are the 2 problems that it solves:

1. React/Gutenberg explodes when changes are made to the text button and internal Gutenberg functions try to change the button text (Essentially is looks for a text node that we swapped out when changing it for our purpose and react explodes)
2. There are a couple of other situations where `savePost` is called and we don't have the ability to identify context and only allow it to trigger in our context because we are currently overriding the Gutenberg state function. (For example, the `trashPost` function also calls `savePost` -- see #12 ).

### New Approach Summary
When users click the checkbox, we show our button and visually hide Gutenbergs... and vice versa. We, therefore, do not have to modify Gutenberg's `savePost` function and won't interfere with current and future callers of `savePost`.

### Drawback
When we load a revision in the block editor in the "future" state, the button reads as "Schedule". We can't really change that at this moment since the fatal error problem identified in #1 still exists in this case. I suggest we leave it until https://github.com/WordPress/gutenberg/issues/14833 is shipped.



