### PR TITLE
Alert users when revision is attempted without future date.

### DIFF
--- a/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
@@ -48,7 +48,7 @@ const UpdateButtonModifier = () => {
 		if ( ! isFutureRevision ) {
 			noticeDispatch.createWarningNotice(
 				__(
-					'We currently only support updates with publish dates in the future. Please select a date in the future.'
+					'We currently only support updates with publish future dates. Please select a date in the future.'
 				),
 				{
 					id: FUTURE_SUPPORT_NOTICE_ID,

--- a/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
@@ -48,7 +48,7 @@ const UpdateButtonModifier = () => {
 		if ( ! isFutureRevision ) {
 			noticeDispatch.createWarningNotice(
 				__(
-					'We currently only support updates with publish future dates. Please select a date in the future.'
+					'We currently only support updates with future publish dates. Please select a date in the future.'
 				),
 				{
 					id: FUTURE_SUPPORT_NOTICE_ID,

--- a/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
@@ -48,7 +48,8 @@ const UpdateButtonModifier = () => {
 		if ( ! isFutureRevision ) {
 			noticeDispatch.createWarningNotice(
 				__(
-					'We currently only support updates with future publish dates. Please select a date in the future.'
+					'We currently only support updates with future publish dates. Please select a date in the future.',
+					'revisions-extended'
 				),
 				{
 					id: FUTURE_SUPPORT_NOTICE_ID,
@@ -73,7 +74,7 @@ const UpdateButtonModifier = () => {
 		if ( error ) {
 			dispatch( 'core/notices' ).createNotice(
 				'error',
-				__( 'Error creating revision.' )
+				__( 'Error creating revision.', 'revisions-extended' )
 			);
 		}
 
@@ -101,7 +102,8 @@ const UpdateButtonModifier = () => {
 								<span>
 									{ ' ' }
 									{ __(
-										'Successfully saved your update for publish on:'
+										'Successfully saved your update for publish on:',
+										'revisions-extended'
 									) }
 								</span>
 								<b style={ { display: 'block' } }>
@@ -110,20 +112,26 @@ const UpdateButtonModifier = () => {
 							</Fragment>
 						) : (
 							<span>
-								{ __( 'Successfully saved your update.' ) }
+								{ __(
+									'Successfully saved your update.',
+									'revisions-extended'
+								) }
 							</span>
 						) }
 					</Notice>
 				}
 				links={ [
 					{
-						text: __( 'Continue editing your update.' ),
+						text: __(
+							'Continue editing your update.',
+							'revisions-extended'
+						),
 						href: getEditUrl( newRevision.id ),
 					},
 					{
 						text: sprintf(
 							// translators: %s: post type.
-							__( 'Edit original %s.' ),
+							__( 'Edit original %s.', 'revisions-extended' ),
 							savedPost.type
 						),
 						href: getEditUrl( savedPost.id ),
@@ -131,7 +139,7 @@ const UpdateButtonModifier = () => {
 					{
 						text: sprintf(
 							// translators: %s: post type.
-							__( 'View all %s updates.' ),
+							__( 'View all %s updates.', 'revisions-extended' ),
 							savedPost.type
 						),
 						href: getAllRevisionUrl( savedPost.type ),


### PR DESCRIPTION
This PR shows a `warning` alert to users when they try to create a revision without a date in the future since we only support that type of revision at this moment.

## Screenshot
![screenshot](https://d.pr/i/59ss1C.png)