### PR TITLE
Redirect users to respective (post/page) future revision lists.

### DIFF
--- a/revisions-extended/includes/revision.php
+++ b/revisions-extended/includes/revision.php
@@ -12,7 +12,7 @@ defined( 'WPINC' ) || die();
  * Actions and filters.
  */
 add_action( 'registered_post_type', __NAMESPACE__ . '\modify_revision_post_type', 10, 2 );
-add_action( 'registered_post_type', __NAMESPACE__ . '\redirect_on_revision_page' );
+add_action( 'load-edit.php', __NAMESPACE__ . '\redirect_on_revision_page' );
 add_filter( 'pre_wp_unique_post_slug', __NAMESPACE__ . '\filter_pre_wp_unique_post_slug', 10, 5 );
 add_filter( 'wp_insert_post_data', __NAMESPACE__ . '\filter_wp_insert_post_data' );
 

--- a/revisions-extended/includes/revision.php
+++ b/revisions-extended/includes/revision.php
@@ -272,7 +272,7 @@ function redirect_on_revision_page() {
 		$redirect_url = '/wp-admin/edit.php?page=post-updates';
 
 		$revision_id      = get_post_id_from_referrer();
-		$parent_post_type = get_parent_post_type_from_referrer( $revision_id );
+		$parent_post_type = get_parent_post_type( $revision_id );
 
 		if ( ! is_null( $parent_post_type ) && 'page' === $parent_post_type ) {
 			$redirect_url = '/wp-admin/edit.php?post_type=page&page=page-updates';

--- a/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
@@ -108,7 +108,7 @@ const UpdateButtonModifier = () => {
 							__( 'View all %s updates.' ),
 							savedPost.type
 						),
-						href: getAllRevisionUrl( savedPost.type ),
+						href: getAllRevisionUrl(),
 					},
 				] }
 			/>

--- a/revisions-extended/src/plugins/revision-editor/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/revision-editor/update-button-modifier/index.js
@@ -81,7 +81,7 @@ const UpdateButtonModifier = () => {
 							__( 'View all %s updates.' ),
 							savedPost.type
 						),
-						href: getAllRevisionUrl( savedPost.type ),
+						href: getAllRevisionUrl(),
 					},
 				] }
 			/>

--- a/revisions-extended/src/utils.js
+++ b/revisions-extended/src/utils.js
@@ -21,12 +21,8 @@ export const getEditUrl = ( postId ) => {
 	return `/wp-admin/post.php?post=${ postId }&action=edit`;
 };
 
-export const getAllRevisionUrl = ( type ) => {
-	if ( type.toLowerCase() === 'page' ) {
-		return '/wp-admin/edit.php?page=page-updates';
-	}
-
-	return '/wp-admin/edit.php?page=post-updates';
+export const getAllRevisionUrl = () => {
+	return '/wp-admin/edit.php?post_type=revision';
 };
 
 export const getFormattedDate = ( date ) => {


### PR DESCRIPTION
Addresses #10.

This PR adds an action that will redirect users to either `/wp-admin/edit.php?page=post-updates` or `/wp-admin/edit.php?post_type=page&page=page-updates` revisions lists if they try to visit:
`/wp-admin/edit.php?post_type=revision`.

It also updates the front end to let this redirect be the source of truth.

