### PR TITLE
REST Controllers: Make parent post data embeddable

### DIFF
--- a/revisions-extended/includes/rest-revision-controller.php
+++ b/revisions-extended/includes/rest-revision-controller.php
@@ -2,7 +2,7 @@
 
 namespace RevisionsExtended;
 
-use WP_Error, WP_Post_Type;
+use WP_Error, WP_Post, WP_Post_Type;
 use WP_REST_Posts_Controller, WP_REST_Revisions_Controller, WP_REST_Request, WP_REST_Response, WP_REST_Server;
 use function RevisionsExtended\Post_Status\get_revision_statuses;
 use function RevisionsExtended\Post_Status\validate_revision_status;
@@ -281,6 +281,35 @@ class REST_Revision_Controller extends WP_REST_Posts_Controller {
 		}
 
 		return $post_status;
+	}
+
+	/**
+	 * Prepares links for the request.
+	 *
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return array Links for the given post.
+	 */
+	protected function prepare_links( $post ) {
+		$links = parent::prepare_links( $post );
+
+		if ( ! empty( $post->post_parent ) ) {
+			$parent    = get_post( $post->post_parent );
+			$post_type = get_post_type( $parent );
+
+			if ( $parent && $post_type ) {
+				$links['parent'] = array(
+					'href'       => rest_url( sprintf(
+						'wp/v2/%s/%d',
+						get_post_type_object( $post_type )->rest_base,
+						$parent->ID
+					) ),
+					'embeddable' => true,
+				);
+			}
+		}
+
+		return $links;
 	}
 
 	/**

--- a/revisions-extended/includes/rest-revisions-controller.php
+++ b/revisions-extended/includes/rest-revisions-controller.php
@@ -280,6 +280,25 @@ class REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 			$response->data['status'] = $post->post_status;
 		}
 
+		if ( in_array( 'parent', $fields, true ) && $response->data['parent'] ) {
+			$parent    = get_post( $response->data['parent'] );
+			$post_type = get_post_type( $parent );
+
+			if ( $parent && $post_type ) {
+				$response->add_link(
+					'parent',
+					rest_url( sprintf(
+						'wp/v2/%s/%d',
+						get_post_type_object( $post_type )->rest_base,
+						$parent->ID
+					) ),
+					array(
+						'embeddable' => true,
+					)
+				);
+			}
+		}
+
 		if ( in_array( 'author', $fields, true ) && $response->data['author'] ) {
 			$response->add_link(
 				'author',


### PR DESCRIPTION
For both the `get_items` and `get_item` endpoints, this adds the option of embedding data about the parent post(s) in the response by adding a `_embed=true` parameter to the request.

The use case is getting access to the parent post's post type, but there could be other applications as well.

Refs #27 