### PR TITLE
Enable querying for all revisions of posts of a particular post type

### DIFF
--- a/revisions-extended/includes/revision-list-table.php
+++ b/revisions-extended/includes/revision-list-table.php
@@ -61,6 +61,7 @@ class Revision_List_Table extends WP_List_Table {
 		$parent_id = filter_input( INPUT_GET, 'p', FILTER_VALIDATE_INT );
 
 		$query_args = array(
+			'post_status'    => wp_list_pluck( get_revision_statuses(), 'name' ),
 			'posts_per_page' => $per_page,
 			'orderby'        => $orderby ?: 'date ID',
 			'order'          => $order ?: 'asc',

--- a/revisions-extended/includes/revision-list-table.php
+++ b/revisions-extended/includes/revision-list-table.php
@@ -5,6 +5,7 @@ namespace RevisionsExtended\Admin;
 use WP_List_Table, WP_Post, WP_Query;
 use function RevisionsExtended\Admin\get_subpage_url;
 use function RevisionsExtended\Post_Status\get_revision_statuses;
+use function RevisionsExtended\Revision\get_revisions_by_parent_type;
 
 defined( 'WPINC' ) || die();
 
@@ -60,8 +61,6 @@ class Revision_List_Table extends WP_List_Table {
 		$parent_id = filter_input( INPUT_GET, 'p', FILTER_VALIDATE_INT );
 
 		$query_args = array(
-			'post_type'      => 'revision',
-			'post_status'    => 'future',
 			'posts_per_page' => $per_page,
 			'orderby'        => $orderby ?: 'date ID',
 			'order'          => $order ?: 'asc',
@@ -75,7 +74,7 @@ class Revision_List_Table extends WP_List_Table {
 			$query_args['post_parent'] = $parent_id;
 		}
 
-		$query = new WP_Query( $query_args );
+		$query = get_revisions_by_parent_type( $this->parent_post_type, $query_args, true );
 
 		$this->items = $query->get_posts();
 

--- a/revisions-extended/includes/revision.php
+++ b/revisions-extended/includes/revision.php
@@ -108,9 +108,8 @@ function get_revisions_by_parent_type( $parent_post_type, $args = array(), $wp_q
 	$args = array_merge(
 		$args,
 		array(
-			'post_type'   => 'revision',
-			'post_status' => 'future',
-			'post__in'    => $valid_ids,
+			'post_type' => 'revision',
+			'post__in'  => $valid_ids,
 		)
 	);
 


### PR DESCRIPTION
This adds a direct DB query for finding revision posts whose parent posts are all of a certain post type. It uses a subquery to accomplish this, which seems like it could potentially be really expensive, so it tries to cache the resulting data, and also invalidate the cache whenever our type of revisions are created or deleted.

This also updates the list table to use this new query, addressing #15 