### PR TITLE
Fetch Parent Post to update language.

### DIFF
--- a/revisions-extended/src/hooks/index.js
+++ b/revisions-extended/src/hooks/index.js
@@ -1,3 +1,4 @@
 export * from './post';
+export * from './parent-post';
 export * from './revision';
 export * from './interface';

--- a/revisions-extended/src/hooks/parent-post.js
+++ b/revisions-extended/src/hooks/parent-post.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useContext, useEffect } from '@wordpress/element';
+
+const StateContext = createContext();
+
+export function ParentPostProvider( { children } ) {
+	useEffect( () => {
+		console.log( 'loaded' );
+	}, [] );
+
+	return (
+		<StateContext.Provider value={ {} }>{ children }</StateContext.Provider>
+	);
+}
+
+export function useParentPost() {
+	const context = useContext( StateContext );
+
+	if ( context === undefined ) {
+		throw new Error( 'useParentPost must be used within a Provider' );
+	}
+
+	return context;
+}

--- a/revisions-extended/src/hooks/parent-post.js
+++ b/revisions-extended/src/hooks/parent-post.js
@@ -1,17 +1,50 @@
 /**
  * WordPress dependencies
  */
-import { createContext, useContext, useEffect } from '@wordpress/element';
+import {
+	createContext,
+	useContext,
+	useEffect,
+	useState,
+} from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
 
 const StateContext = createContext();
 
-export function ParentPostProvider( { children } ) {
+export function ParentPostProvider( { children, links } ) {
+	const [ parent, setParent ] = useState( {} );
+
+	const getHref = () => {
+		try {
+			return links.parent[ 0 ].href;
+		} catch ( ex ) {}
+	};
+
 	useEffect( () => {
-		console.log( 'loaded' );
-	}, [] );
+		const getParentPost = async ( path ) => {
+			try {
+				const res = await apiFetch( {
+					path,
+					method: 'GET',
+				} );
+
+				setParent( res );
+			} catch ( ex ) {
+				// TO DO: Maybe consider add a default object since the ui depends on the type
+			}
+		};
+
+		const href = getHref();
+
+		if ( ! href ) return;
+
+		getParentPost( href );
+	}, [ links ] );
 
 	return (
-		<StateContext.Provider value={ {} }>{ children }</StateContext.Provider>
+		<StateContext.Provider value={ parent }>
+			{ children }
+		</StateContext.Provider>
 	);
 }
 

--- a/revisions-extended/src/plugins/revision-editor/index.js
+++ b/revisions-extended/src/plugins/revision-editor/index.js
@@ -14,7 +14,7 @@ import TrashModifier from './trash-modifier';
 import PluginPostStatusInfo from './plugin-post-status-info';
 import { pluginNamespace, getEditUrl } from '../../utils';
 
-import { InterfaceProvider, usePost } from '../../hooks';
+import { InterfaceProvider, usePost, ParentPostProvider } from '../../hooks';
 
 /**
  * Module Constants
@@ -31,11 +31,13 @@ const PluginWrapper = () => {
 
 	return (
 		<InterfaceProvider btnText={ __( 'Update' ) }>
-			<DocumentSettingsPanel />
-			<UpdateButtonModifier />
-			<RevisionIndicator />
-			<TrashModifier />
-			<PluginPostStatusInfo />
+			<ParentPostProvider>
+				<DocumentSettingsPanel />
+				<UpdateButtonModifier />
+				<RevisionIndicator />
+				<TrashModifier />
+				<PluginPostStatusInfo />
+			</ParentPostProvider>
 		</InterfaceProvider>
 	);
 };

--- a/revisions-extended/src/plugins/revision-editor/index.js
+++ b/revisions-extended/src/plugins/revision-editor/index.js
@@ -31,7 +31,7 @@ const PluginWrapper = () => {
 
 	return (
 		<InterfaceProvider btnText={ __( 'Update' ) }>
-			<ParentPostProvider>
+			<ParentPostProvider links={ savedPost._links }>
 				<DocumentSettingsPanel />
 				<UpdateButtonModifier />
 				<RevisionIndicator />

--- a/revisions-extended/src/plugins/revision-editor/revision-indicator/index.js
+++ b/revisions-extended/src/plugins/revision-editor/revision-indicator/index.js
@@ -24,7 +24,7 @@ export const NOTICE_ID = 'revisions-extended-notice';
 
 const RevisionIndicator = () => {
 	const { savedPost } = usePost();
-	const { type: parentType } = useParentPost();
+	const { type: parentType, getLabel } = useParentPost();
 
 	const getRevisionType =
 		savedPost.status === POST_STATUS_SCHEDULED
@@ -41,7 +41,7 @@ const RevisionIndicator = () => {
 			// translators: %1$s: url %2$s: post type.
 			__( '[ <a href="%1$s">Edit %2$s</a>.' ),
 			getEditUrl( savedPost.parent ),
-			parentType
+			getLabel( 'singular_name' ).toLowerCase()
 		),
 		` | <a href="/wp-admin/revision.php?revision=${
 			savedPost.id

--- a/revisions-extended/src/plugins/revision-editor/revision-indicator/index.js
+++ b/revisions-extended/src/plugins/revision-editor/revision-indicator/index.js
@@ -13,7 +13,7 @@ import { dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 
-import { usePost } from '../../../hooks';
+import { usePost, useParentPost } from '../../../hooks';
 import { POST_STATUS_SCHEDULED } from '../../../settings';
 import { getEditUrl } from '../../../utils';
 
@@ -24,6 +24,7 @@ export const NOTICE_ID = 'revisions-extended-notice';
 
 const RevisionIndicator = () => {
 	const { savedPost } = usePost();
+	const { type: parentType } = useParentPost();
 
 	const getRevisionType =
 		savedPost.status === POST_STATUS_SCHEDULED
@@ -32,25 +33,30 @@ const RevisionIndicator = () => {
 
 	const notes = [
 		sprintf(
-			// translators: %s: post type.
+			// translators: %s: revision type.
 			__( 'You are currently editing a <b>%s update</b>.' ),
 			getRevisionType
 		),
-		`[ <a href="${ getEditUrl( savedPost.parent ) }">${ __(
-			'Edit post'
-		) }</a>`,
+		sprintf(
+			// translators: %1$s: url %2$s: post type.
+			__( '[ <a href="%1$s">Edit %2$s</a>.' ),
+			getEditUrl( savedPost.parent ),
+			parentType
+		),
 		` | <a href="/wp-admin/revision.php?revision=${
 			savedPost.id
 		}&gutenberg=true" />${ __( 'See changes' ) }</a> ]`,
 	];
 
 	useEffect( () => {
+		if ( ! parentType ) return;
+
 		dispatch( 'core/notices' ).createNotice( 'warning', notes.join( ' ' ), {
 			__unstableHTML: true,
 			id: NOTICE_ID,
 			isDismissible: false,
 		} );
-	}, [] );
+	}, [ parentType ] );
 
 	return null;
 };

--- a/revisions-extended/src/plugins/revision-editor/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/revision-editor/update-button-modifier/index.js
@@ -26,7 +26,7 @@ const UpdateButtonModifier = () => {
 	const [ showSuccess, setShowSuccess ] = useState( false );
 	const { setBtnDefaults } = useInterface();
 	const { savedPost, didPostSaveRequestSucceed, savePost } = usePost();
-	const { type: parentType } = useParentPost();
+	const { type: parentType, getLabel } = useParentPost();
 	const { publish } = useRevision();
 
 	const _savePost = async () => {
@@ -77,7 +77,7 @@ const UpdateButtonModifier = () => {
 						text: sprintf(
 							// translators: %s: post type.
 							__( 'View published %s.' ),
-							parentType
+							getLabel( 'singular_name' ).toLowerCase()
 						),
 						href: `/?p=${ savedPost.parent }`,
 					},
@@ -85,7 +85,7 @@ const UpdateButtonModifier = () => {
 						text: sprintf(
 							// translators: %s: post type.
 							__( 'Edit original %s.' ),
-							parentType
+							getLabel( 'singular_name' ).toLowerCase()
 						),
 						href: getEditUrl( savedPost.parent ),
 					},
@@ -93,7 +93,7 @@ const UpdateButtonModifier = () => {
 						text: sprintf(
 							// translators: %s: post type.
 							__( 'View all %s updates.' ),
-							parentType
+							getLabel( 'singular_name' ).toLowerCase()
 						),
 						href: getAllRevisionUrl( parentType ),
 					},

--- a/revisions-extended/src/plugins/revision-editor/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/revision-editor/update-button-modifier/index.js
@@ -14,13 +14,19 @@ import { Notice } from '@wordpress/components';
  * Internal dependencies
  */
 import { ConfirmWindow } from '../../../components';
-import { usePost, useRevision, useInterface } from '../../../hooks';
+import {
+	usePost,
+	useRevision,
+	useInterface,
+	useParentPost,
+} from '../../../hooks';
 import { getEditUrl, getAllRevisionUrl } from '../../../utils';
 
 const UpdateButtonModifier = () => {
 	const [ showSuccess, setShowSuccess ] = useState( false );
 	const { setBtnDefaults } = useInterface();
 	const { savedPost, didPostSaveRequestSucceed, savePost } = usePost();
+	const { type: parentType } = useParentPost();
 	const { publish } = useRevision();
 
 	const _savePost = async () => {
@@ -68,20 +74,28 @@ const UpdateButtonModifier = () => {
 				}
 				links={ [
 					{
-						text: __( 'View published post.' ),
+						text: sprintf(
+							// translators: %s: post type.
+							__( 'View published %s.' ),
+							parentType
+						),
 						href: `/?p=${ savedPost.parent }`,
 					},
 					{
-						text: __( 'Edit original post.' ),
+						text: sprintf(
+							// translators: %s: post type.
+							__( 'Edit original %s.' ),
+							parentType
+						),
 						href: getEditUrl( savedPost.parent ),
 					},
 					{
 						text: sprintf(
 							// translators: %s: post type.
 							__( 'View all %s updates.' ),
-							savedPost.type
+							parentType
 						),
-						href: getAllRevisionUrl( savedPost.type ),
+						href: getAllRevisionUrl( parentType ),
 					},
 				] }
 			/>

--- a/revisions-extended/src/utils.js
+++ b/revisions-extended/src/utils.js
@@ -26,7 +26,7 @@ export const getAllRevisionUrl = ( type ) => {
 		return '/wp-admin/edit.php?page=post-updates';
 	}
 
-	return `/wp-admin/edit.php?post_type=${ type }&page=page-updates`;
+	return `/wp-admin/edit.php?post_type=${ type }&page=${ type }-updates`;
 };
 
 export const getFormattedDate = ( date ) => {

--- a/revisions-extended/src/utils.js
+++ b/revisions-extended/src/utils.js
@@ -22,11 +22,11 @@ export const getEditUrl = ( postId ) => {
 };
 
 export const getAllRevisionUrl = ( type ) => {
-	if ( type.toLowerCase() === 'page' ) {
-		return '/wp-admin/edit.php?page=page-updates';
+	if ( type.toLowerCase() === 'post' ) {
+		return '/wp-admin/edit.php?page=post-updates';
 	}
 
-	return '/wp-admin/edit.php?page=post-updates';
+	return `/wp-admin/edit.php?post_type=${ type }&page=page-updates`;
 };
 
 export const getFormattedDate = ( date ) => {


### PR DESCRIPTION
This PR adds a data provider to grab the paren post and make it available.

There are a few PRs that will rely on this provider:
- #24 
- #22 

## Question:
What's the best way to concatenate the post type into a string. I am currently piping the `type` property from the REST object to make a sentence like: `Edit all ${post.type}`. 

**Is it best practice to do it using a mapping function/object?**
```
const strings = {
   post: __('post', 'revisions-extended'),
   page: __('page', 'revisions-extended'),
   custom: __('custom', 'revisions-extended'),
}
...

Edit all ${strings[post.type]}

```
