### PR TITLE
Replace: Post Status with our own document panel.

### DIFF
--- a/revisions-extended/src/plugins/revision-editor/document-settings-panel/index.js
+++ b/revisions-extended/src/plugins/revision-editor/document-settings-panel/index.js
@@ -6,22 +6,45 @@ import { useEffect } from 'react';
 /**
  * WordPress dependencies
  */
-import { dispatch } from '@wordpress/data';
+import { select, dispatch } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies
  */
 import PostSchedule from './post-schedule';
+import { GUTENBERG_PLUGIN_NAMESPACE } from '../index';
+
+/**
+ * Module Constants
+ */
+
+const STORE_KEY = 'core/edit-post';
+const PANEL_NAME = 'scheduled-revisions';
 
 const DocumentSettingsPanel = () => {
 	useEffect( () => {
 		// Hide the default panel;
-		dispatch( 'core/edit-post' ).removeEditorPanel( 'post-status' );
+		dispatch( STORE_KEY ).removeEditorPanel( 'post-status' );
+
+		// Make sure we turn on our panel
+		const togglePanelOn = async () => {
+			const isToggledOn = await select( STORE_KEY ).isEditorPanelOpened(
+				`${ GUTENBERG_PLUGIN_NAMESPACE }/${ PANEL_NAME }`
+			);
+
+			if ( ! isToggledOn ) {
+				await dispatch( STORE_KEY ).toggleEditorPanelOpened(
+					`${ GUTENBERG_PLUGIN_NAMESPACE }/${ PANEL_NAME }`
+				);
+			}
+		};
+
+		togglePanelOn();
 	}, [] );
 
 	return (
-		<PluginDocumentSettingPanel name="scheduled-revisions">
+		<PluginDocumentSettingPanel name={ PANEL_NAME }>
 			<PostSchedule />
 		</PluginDocumentSettingPanel>
 	);

--- a/revisions-extended/src/plugins/revision-editor/document-settings-panel/index.js
+++ b/revisions-extended/src/plugins/revision-editor/document-settings-panel/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+
+/**
+ * Internal dependencies
+ */
+import PostSchedule from './post-schedule';
+
+const DocumentSettingsPanel = () => {
+	useEffect( () => {
+		// Hide the default panel;
+		dispatch( 'core/edit-post' ).removeEditorPanel( 'post-status' );
+	}, [] );
+
+	return (
+		<PluginDocumentSettingPanel name="scheduled-revisions">
+			<PostSchedule />
+		</PluginDocumentSettingPanel>
+	);
+};
+
+export default DocumentSettingsPanel;

--- a/revisions-extended/src/plugins/revision-editor/document-settings-panel/post-schedule.js
+++ b/revisions-extended/src/plugins/revision-editor/document-settings-panel/post-schedule.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PanelRow, Dropdown, Button } from '@wordpress/components';
+import {
+	PostSchedule as PostScheduleForm,
+	PostScheduleLabel,
+	PostScheduleCheck,
+} from '@wordpress/editor';
+
+export function PostSchedule() {
+	return (
+		<PostScheduleCheck>
+			<PanelRow className="edit-post-post-schedule">
+				<span>{ __( 'Publish', 'revisions-extended' ) }</span>
+				<Dropdown
+					position="bottom left"
+					contentClassName="edit-post-post-schedule__dialog"
+					renderToggle={ ( { onToggle, isOpen } ) => (
+						<>
+							<Button
+								className="edit-post-post-schedule__toggle"
+								onClick={ onToggle }
+								aria-expanded={ isOpen }
+								isTertiary
+							>
+								<PostScheduleLabel />
+							</Button>
+						</>
+					) }
+					renderContent={ () => <PostScheduleForm /> }
+				/>
+			</PanelRow>
+		</PostScheduleCheck>
+	);
+}
+
+export default PostSchedule;

--- a/revisions-extended/src/plugins/revision-editor/index.js
+++ b/revisions-extended/src/plugins/revision-editor/index.js
@@ -7,6 +7,7 @@ import { registerPlugin } from '@wordpress/plugins';
 /**
  * Internal dependencies
  */
+import DocumentSettingsPanel from './document-settings-panel';
 import UpdateButtonModifier from './update-button-modifier';
 import RevisionIndicator from './revision-indicator';
 import TrashModifier from './trash-modifier';
@@ -22,8 +23,10 @@ const PluginWrapper = () => {
 	if ( ! isRevision ) {
 		window.location.href = getEditUrl( savedPost.parent );
 	}
+
 	return (
 		<InterfaceProvider btnText={ __( 'Update' ) }>
+			<DocumentSettingsPanel />
 			<UpdateButtonModifier />
 			<RevisionIndicator />
 			<TrashModifier />

--- a/revisions-extended/src/plugins/revision-editor/index.js
+++ b/revisions-extended/src/plugins/revision-editor/index.js
@@ -16,6 +16,11 @@ import { pluginNamespace, getEditUrl } from '../../utils';
 
 import { InterfaceProvider, usePost } from '../../hooks';
 
+/**
+ * Module Constants
+ */
+export const GUTENBERG_PLUGIN_NAMESPACE = `${ pluginNamespace }-plugin-wrapper`;
+
 const PluginWrapper = () => {
 	const { isRevision, savedPost } = usePost();
 
@@ -35,6 +40,6 @@ const PluginWrapper = () => {
 	);
 };
 
-registerPlugin( `${ pluginNamespace }-plugin-wrapper`, {
+registerPlugin( GUTENBERG_PLUGIN_NAMESPACE, {
 	render: PluginWrapper,
 } );


### PR DESCRIPTION
In lieu of a growing list of CSS tricks to make the `<PostStatus>` work for our use case, we created our own `DocumentSettingsPanel`.

This addresses: #28.

This PR introduces a very simple view:

![](https://d.pr/i/tDXu0y.png)

It's missing "Publish immediately" & "Delete Permanently" because those are in PRs that introduced changes that are bound to conflict. We should wait to merge the UI together until then.
