### PR TITLE
Handle cron events for scheduled updates

### DIFF
--- a/revisions-extended/includes/cron.php
+++ b/revisions-extended/includes/cron.php
@@ -11,6 +11,8 @@ defined( 'WPINC' ) || die();
  */
 add_action( 'future_revision', __NAMESPACE__ . '\unschedule_default_publish', 20 );
 add_action( 'future_revision', __NAMESPACE__ . '\schedule_update', 30, 2 );
+add_action( 'wp_delete_post_revision', __NAMESPACE__ . '\unschedule_update', 10, 2 );
+add_action( 'rest_delete_revision', __NAMESPACE__ . '\unschedule_update', 10, 2 );
 
 /**
  * Remove the default scheduled event that would attempt to publish the future revision post.
@@ -35,4 +37,28 @@ function schedule_update( $post_id, $post ) {
 	$time = strtotime( $post->post_date_gmt . ' GMT' );
 
 	wp_schedule_single_event( $time, 'publish_future_revision', array( $post->ID ) );
+}
+
+/**
+ * Unschedule a future event to update a parent post with a revision when the revision is deleted.
+ *
+ * @param int|WP_Post $revision
+ * @param WP_Post|\WP_REST_Request
+ */
+function unschedule_update( $revision, $revision2 ) {
+	$update = null;
+
+	if ( $revision instanceof WP_Post ) {
+		$update = $revision;
+	} elseif ( $revision2 instanceof WP_Post ) {
+		$update = $revision2;
+	}
+
+	if ( ! $update ) {
+		return;
+	}
+
+	if ( 'future' === get_post_status( $update ) ) {
+		wp_clear_scheduled_hook( 'publish_future_revision', array( $update->ID ) );
+	}
 }

--- a/revisions-extended/includes/cron.php
+++ b/revisions-extended/includes/cron.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace RevisionsExtended\Cron;
+
+use WP_Post;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * Actions and filters.
+ */
+add_action( 'future_revision', __NAMESPACE__ . '\unschedule_default_publish', 20 );
+add_action( 'future_revision', __NAMESPACE__ . '\schedule_update', 30, 2 );
+
+/**
+ * Remove the default scheduled event that would attempt to publish the future revision post.
+ *
+ * @param int $post_id
+ *
+ * @return void
+ */
+function unschedule_default_publish( $post_id ) {
+	wp_clear_scheduled_hook( 'publish_future_post', array( $post_id ) );
+}
+
+/**
+ * Schedule a future event to update the parent post with the future revision.
+ *
+ * @param int     $post_id
+ * @param WP_Post $post
+ *
+ * @return void
+ */
+function schedule_update( $post_id, $post ) {
+	$time = strtotime( $post->post_date_gmt . ' GMT' );
+
+	wp_schedule_single_event( $time, 'publish_future_revision', array( $post->ID ) );
+}

--- a/revisions-extended/includes/revision.php
+++ b/revisions-extended/includes/revision.php
@@ -202,6 +202,8 @@ function put_post_revision( $post = null, $autosave = false ) {
  * Uses the same mechanism as for restoring a past revision, but if the revision is pending/scheduled,
  * it will be converted to a standard revision first, using the current time for the post date.
  *
+ * Note that this can only complete successfully if the parent post is published.
+ *
  * @param int $revision_id
  *
  * @return int|WP_Error The ID of the updated post. Otherwise a WP_Error.
@@ -212,6 +214,14 @@ function update_post_from_revision( $revision_id ) {
 		return new WP_Error(
 			'invalid_revision_id',
 			__( 'Invalid revision ID.', 'revisions-extended' )
+		);
+	}
+
+	$parent = get_post( $revision->post_parent );
+	if ( 'publish' !== get_post_status( $parent ) ) {
+		return new WP_Error(
+			'invalid_parent_post',
+			__( 'Parent post is not published.', 'revisions-extended' )
 		);
 	}
 

--- a/revisions-extended/includes/revision.php
+++ b/revisions-extended/includes/revision.php
@@ -257,6 +257,9 @@ function update_post_from_revision( $revision_id ) {
 		$result = $revision->post_parent;
 	}
 
+	// Ensure there are no more scheduled publish events for this revision.
+	wp_clear_scheduled_hook( 'publish_future_revision', array( $revision->ID ) );
+
 	return $result;
 }
 

--- a/revisions-extended/index.php
+++ b/revisions-extended/index.php
@@ -34,6 +34,7 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\initialize_rest_routes', 100 );
 function load_files() {
 	require_once get_includes_path() . 'admin.php';
 	require_once get_includes_path() . 'capabilities.php';
+	require_once get_includes_path() . 'cron.php';
 	require_once get_includes_path() . 'post-status.php';
 	require_once get_includes_path() . 'rest-revision-controller.php';
 	require_once get_includes_path() . 'rest-revisions-controller.php';


### PR DESCRIPTION
- [x] Cancel the Core scheduled event that attempts to actually publish our future revision
- [x] Add a new event that will run `update_post_from_revision()` at the appropriate time
- [x] Ensure that our custom event gets removed if the revision is deleted
- [x] Ensure that our custom event gets removed if the revision is immediately published
- [ ] ~Ensure that our custom event gets removed if the parent post does not have a `publish` status~

Fixes #18 