### PR TITLE
Context must be passed as a query string param.

### DIFF
--- a/revisions-extended/src/hooks/parent-post.js
+++ b/revisions-extended/src/hooks/parent-post.js
@@ -29,11 +29,8 @@ export function ParentPostProvider( { children, links } ) {
 		 */
 		const getPostTypeLabel = async ( postType ) => {
 			return await apiFetch( {
-				path: `wp/v2/types/${ postType }`,
+				path: `wp/v2/types/${ postType }?context=edit`,
 				method: 'GET',
-				data: {
-					context: 'edit'
-				}
 			} );
 		};
 


### PR DESCRIPTION
This PR fixes the link on the WP Button.

It appears like the regression was introduced in this change: 
https://github.com/coreymckrill/revisions-extended/commit/e31f9f0198caf367718226e1575cfddff8882537

`context=edit` cannot be passed as data; it makes the `apiFetch` method hang and never resolve.

Now, that commit was introduced to `Avoids a couple of API call 404s`. Can whatever that issue was be logged so we can address it some other way?

Notes: I want to cycle back and add better testing in the near future to catch these regressions. If this isn't a priority I can do it in this pr as well.