### PR TITLE
Change the link to the revision comparison view.

### DIFF
--- a/revisions-extended/src/plugins/revision-editor/revision-indicator/index.js
+++ b/revisions-extended/src/plugins/revision-editor/revision-indicator/index.js
@@ -15,7 +15,7 @@ import { dispatch } from '@wordpress/data';
 
 import { usePost, useParentPost } from '../../../hooks';
 import { POST_STATUS_SCHEDULED } from '../../../settings';
-import { getEditUrl } from '../../../utils';
+import { getEditUrl, getCompareLink } from '../../../utils';
 
 /**
  * Module Constants
@@ -43,9 +43,9 @@ const RevisionIndicator = () => {
 			getEditUrl( savedPost.parent ),
 			getLabel( 'singular_name' ).toLowerCase()
 		),
-		` | <a href="/wp-admin/revision.php?revision=${
-			savedPost.id
-		}&gutenberg=true" />${ __( 'See changes' ) }</a> ]`,
+		` | <a href="${ getCompareLink( savedPost.id ) }" />${ __(
+			'See changes'
+		) }</a> ]`,
 	];
 
 	useEffect( () => {

--- a/revisions-extended/src/utils.js
+++ b/revisions-extended/src/utils.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { format } from '@wordpress/date';
+import { addQueryArgs } from '@wordpress/url';
 
 export const pluginNamespace = 'revisions-extended';
 export const pluginName = __( 'Revisions Extended', 'revisions-extended' );
@@ -27,6 +28,19 @@ export const getAllRevisionUrl = ( type ) => {
 	}
 
 	return `/wp-admin/edit.php?post_type=${ type }&page=${ type }-updates`;
+};
+
+/**
+ * Returns the link for the revision comparison page
+ *
+ * @param {string} revisionId
+ * @return {string} Url
+ */
+export const getCompareLink = ( revisionId ) => {
+	return addQueryArgs( 'revision.php', {
+		page: 'compare-updates',
+		revision_id: revisionId,
+	} );
 };
 
 export const getFormattedDate = ( date ) => {


### PR DESCRIPTION
Update the URL that allows users to view the difference between the origin post/page and the 'update'.

Addresses: #5 
