### PR TITLE
Wrap the plugin code in error boundaries to make sure we won't crash the editor.

### DIFF
--- a/revisions-extended/src/components/error-boundary/index.js
+++ b/revisions-extended/src/components/error-boundary/index.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { dispatch } from '@wordpress/data';
+
+class ErrorBoundary extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = { hasError: false };
+	}
+
+	static getDerivedStateFromError() {
+		return { hasError: true };
+	}
+
+	componentDidCatch() {
+		dispatch( 'core/notices' ).createWarningNotice(
+			__(
+				'Something went wrong with the "Revision Extended" plugin.',
+				'revisions-extended'
+			)
+		);
+	}
+
+	render() {
+		if ( this.state.hasError ) {
+			return null;
+		}
+
+		return this.props.children;
+	}
+}
+
+export default ErrorBoundary;

--- a/revisions-extended/src/components/error-boundary/index.js
+++ b/revisions-extended/src/components/error-boundary/index.js
@@ -22,7 +22,7 @@ class ErrorBoundary extends Component {
 	componentDidCatch() {
 		dispatch( 'core/notices' ).createWarningNotice(
 			__(
-				'Something went wrong with the "Revision Extended" plugin.',
+				'Something went wrong with the "Revisions Extended" plugin.',
 				'revisions-extended'
 			)
 		);

--- a/revisions-extended/src/components/index.js
+++ b/revisions-extended/src/components/index.js
@@ -1,4 +1,5 @@
 import RevisionList from './revision-list';
 import ConfirmWindow from './confirm-window';
+import ErrorBoundary from './error-boundary';
 
-export { RevisionList, ConfirmWindow };
+export { RevisionList, ConfirmWindow, ErrorBoundary };

--- a/revisions-extended/src/plugins/editor-modifications/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/index.js
@@ -7,6 +7,7 @@ import { registerPlugin } from '@wordpress/plugins';
 /**
  * Internal dependencies
  */
+import { ErrorBoundary } from '../../components';
 import UpdateButtonModifier from './update-button-modifier';
 import PluginPostStatusInfo from './plugin-post-status-info';
 import DocumentSettingsPanel from './document-settings-panel';
@@ -22,11 +23,13 @@ const MainPlugin = () => {
 	}
 
 	return (
-		<InterfaceProvider btnText={ __( 'Create update' ) }>
-			<UpdateButtonModifier />
-			<PluginPostStatusInfo />
-			<DocumentSettingsPanel />
-		</InterfaceProvider>
+		<ErrorBoundary>
+			<InterfaceProvider btnText={ __( 'Create update' ) }>
+				<UpdateButtonModifier />
+				<PluginPostStatusInfo />
+				<DocumentSettingsPanel />
+			</InterfaceProvider>
+		</ErrorBoundary>
 	);
 };
 

--- a/revisions-extended/src/plugins/revision-editor/index.js
+++ b/revisions-extended/src/plugins/revision-editor/index.js
@@ -7,6 +7,7 @@ import { registerPlugin } from '@wordpress/plugins';
 /**
  * Internal dependencies
  */
+import { ErrorBoundary } from '../../components';
 import DocumentSettingsPanel from './document-settings-panel';
 import UpdateButtonModifier from './update-button-modifier';
 import RevisionIndicator from './revision-indicator';
@@ -29,14 +30,16 @@ const PluginWrapper = () => {
 	}
 
 	return (
-		<InterfaceProvider btnText={ __( 'Publish' ) }>
-			<ParentPostProvider links={ savedPost._links }>
-				<DocumentSettingsPanel />
-				<UpdateButtonModifier />
-				<RevisionIndicator />
-				<WPButtonModifier />
-			</ParentPostProvider>
-		</InterfaceProvider>
+		<ErrorBoundary>
+			<InterfaceProvider btnText={ __( 'Publish' ) }>
+				<ParentPostProvider links={ savedPost._links }>
+					<DocumentSettingsPanel />
+					<UpdateButtonModifier />
+					<RevisionIndicator />
+					<WPButtonModifier />
+				</ParentPostProvider>
+			</InterfaceProvider>
+		</ErrorBoundary>
 	);
 };
 


### PR DESCRIPTION
Since our plugin is considered an extension to the editor, we should wrap it in an error boundary to make sure we don't kill the editor if there's an issue. 

**Example of when an error is thrown**

![](https://d.pr/i/NcER9r.png)