### PR TITLE
Remove confirm prompt on navigate away after update creation.

### DIFF
--- a/revisions-extended/src/editor-modifications-styles.css
+++ b/revisions-extended/src/editor-modifications-styles.css
@@ -1,0 +1,5 @@
+/** Overrides **/
+
+.components-modal__screen-overlay {
+	background-color: rgba(255,255,255,0.95);
+}

--- a/revisions-extended/src/editor-modifications.js
+++ b/revisions-extended/src/editor-modifications.js
@@ -2,4 +2,4 @@
  * Internal dependencies
  */
 import './plugins/editor-modifications';
-import './styles.css';
+import './editor-modifications-styles.css';

--- a/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
@@ -44,13 +44,21 @@ const UpdateButtonModifier = () => {
 	 * Clear the current post edits to avoid triggering dirty state
 	 */
 	const clearPostEdits = async () => {
-		const entity = { kind: 'postType', name: 'post', id: savedPost.id };
+		const entity = {
+			kind: 'postType',
+			name: savedPost.type,
+			id: savedPost.id,
+		};
 
 		const edits = select( 'core' ).getEntityRecordEdits(
 			entity.kind,
 			entity.name,
 			entity.id
 		);
+
+		if ( ! edits ) {
+			return;
+		}
 
 		const clearedEdits = {};
 

--- a/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/update-button-modifier/index.js
@@ -128,9 +128,6 @@ const UpdateButtonModifier = () => {
 			);
 		}
 
-		// We clear the post edits so users can navigate away without the "dirty" browser prompt.
-		await clearPostEdits();
-
 		if ( data ) {
 			setNewRevision( data );
 		}
@@ -143,6 +140,14 @@ const UpdateButtonModifier = () => {
 			},
 		} );
 	}, [] );
+
+	useEffect( () => {
+		if ( newRevision ) {
+			( async () => {
+				await clearPostEdits();
+			} )();
+		}
+	}, [ newRevision ] );
 
 	if ( newRevision ) {
 		return (

--- a/revisions-extended/src/revision-editor.js
+++ b/revisions-extended/src/revision-editor.js
@@ -2,5 +2,4 @@
  * Internal dependencies
  */
 import './plugins/revision-editor';
-import './styles.css';
 import './revision-editor-styles.css';

--- a/revisions-extended/src/styles.css
+++ b/revisions-extended/src/styles.css
@@ -1,5 +1,0 @@
-:root {
-	--global--alert-yellow: #f0b849;
-	--global--alert-red: #cc1818;
-	--global--alert-green: #4ab866;
-}


### PR DESCRIPTION
This PR deletes record edits to allow the user to navigate away without a browser prompt. 

Note: the content will change in the editor behind the popup.

Fixes: #49 

### Screenshots
![](https://d.pr/i/7qxiLc.gif)


