### PR TITLE
Handle UX for updates of posts that are no longer published

### DIFF
--- a/revisions-extended/assets/edit-revisions.css
+++ b/revisions-extended/assets/edit-revisions.css
@@ -1,4 +1,4 @@
 .column-parent a,
-.column-scheduled strong {
+.column-status strong {
     display: block;
 }

--- a/revisions-extended/includes/admin.php
+++ b/revisions-extended/includes/admin.php
@@ -588,14 +588,22 @@ function filter_menu_file_for_edit_screen( $file ) {
  * @return mixed
  */
 function filter_display_post_states( $post_states, $post ) {
-	if ( post_type_supports( get_post_type( $post ), 'revisions' ) ) {
+	if ( 'revision' === get_post_type( $post ) ) {
+		$post_states = array();
+		$parent      = get_post( $post->post_parent );
+
+		// TODO Replace with `is_post_publicly_viewable()` when WP 5.7 lands.
+		if ( 'publish' !== get_post_status( $parent ) ) {
+			$post_states['suspended'] = _x( 'Suspended', 'post status', 'revisions-extended' );
+		}
+	} elseif ( post_type_supports( get_post_type( $post ), 'revisions' ) ) {
 		$args      = array(
 			'post_status' => 'future',
 		);
 		$revisions = get_post_revisions( $post, $args );
 
 		if ( ! empty( $revisions ) ) {
-			$post_states['has_scheduled_updates'] = _x( 'Scheduled Updates', 'post status', 'revisions-extended' );
+			$post_states['has_updates'] = _x( 'Has Updates', 'post status', 'revisions-extended' );
 		}
 	}
 

--- a/revisions-extended/includes/admin.php
+++ b/revisions-extended/includes/admin.php
@@ -603,7 +603,13 @@ function filter_display_post_states( $post_states, $post ) {
 		$revisions = get_post_revisions( $post, $args );
 
 		if ( ! empty( $revisions ) ) {
-			$post_states['has_updates'] = _x( 'Has Updates', 'post status', 'revisions-extended' );
+			$post_states['has_updates'] = _nx(
+				'Has Update',
+				'Has Updates',
+				count( $revisions ),
+				'post status',
+				'revisions-extended'
+			);
 		}
 	}
 

--- a/revisions-extended/includes/cron.php
+++ b/revisions-extended/includes/cron.php
@@ -45,6 +45,9 @@ function schedule_update( $post_id, $post ) {
 /**
  * Unschedule a future event to update a parent post with a revision when the revision is deleted.
  *
+ * This is hooked to two different actions that provide parameters in different orders. Thus sometimes
+ * the first parameter is the WP_Post object, and sometimes the second one is.
+ *
  * @param int|WP_Post $revision
  * @param WP_Post|\WP_REST_Request
  */

--- a/revisions-extended/includes/revision-list-table.php
+++ b/revisions-extended/includes/revision-list-table.php
@@ -433,9 +433,9 @@ class Revision_List_Table extends WP_List_Table {
 	/**
 	 * Generates and display row actions links for the list table.
 	 *
-	 * @param object|array $post        The post being acted upon.
-	 * @param string       $column_name Current column name.
-	 * @param string       $primary     Primary column name.
+	 * @param WP_Post $post        The post being acted upon.
+	 * @param string  $column_name Current column name.
+	 * @param string  $primary     Primary column name.
 	 *
 	 * @return string The row actions HTML, or an empty string
 	 *                if the current column is not the primary column.
@@ -447,8 +447,9 @@ class Revision_List_Table extends WP_List_Table {
 
 		$screen        = get_current_screen();
 		$can_edit_post = current_user_can( 'edit_post', $post->ID );
-		$actions       = array();
 		$title         = _draft_or_post_title( $post );
+		$parent        = get_post( $post->post_parent );
+		$actions       = array();
 
 		// Edit.
 		if ( $can_edit_post ) {
@@ -473,7 +474,7 @@ class Revision_List_Table extends WP_List_Table {
 		}
 
 		// Publish.
-		if ( $can_edit_post ) {
+		if ( $can_edit_post && 'publish' === get_post_status( $parent ) ) { // TODO Replace with `is_post_publicly_viewable()` when WP 5.7 lands.
 			$url = add_query_arg(
 				array(
 					'action'      => 'publish',

--- a/revisions-extended/includes/revision.php
+++ b/revisions-extended/includes/revision.php
@@ -218,6 +218,7 @@ function update_post_from_revision( $revision_id ) {
 	}
 
 	$parent = get_post( $revision->post_parent );
+	// TODO Replace with `is_post_publicly_viewable()` when WP 5.7 lands.
 	if ( 'publish' !== get_post_status( $parent ) ) {
 		return new WP_Error(
 			'invalid_parent_post',


### PR DESCRIPTION
When a post becomes unpublished (draft, pending, trashed), its scheduled/pending updates are still there. (This is not the case when a post is permanently deleted; its revisions are also deleted at that time.) It seems best to keep these updates when this happens, as it's quite possible that the post will be republished in the future.

This PR takes a very hands-off approach to handling these updates. It doesn't change any of their data at all, it just changes how they are presented (and how their parent posts are presented) in the WP Admin. The rationale is that if we modify updates when the parent status changes, we have to then modify the updates again when the parent is republished, and both of those processes would be fragile and potentially miss edge cases. Fortunately, the updates are pretty harmless the way they are. If a scheduled update's cron event triggers, and the parent post is not published, the cron silently fails, and the update continues on with a `future` status, but no further cron job scheduled.

So, here's what this PR actually does:

* In the Updates list table:
  * If a scheduled update has a publish date in the past, it shows "Missed Schedule" (same as how Core handles future posts with missed dates)
  * If an update's parent post is not currently published:
    * Show a "Suspended" post state next to the update's title (post "states" are used in Core's posts list table to indicate things like Pending, Draft, Front Page, and Privacy Policy Page)
    * Indicate in the "An update to" column that the parent post is not published and show its current post status
* In the Posts list table:
  * If a post has updates, add a "Has Updates" post state

Fixes #37 

**Screenshots**

Updates list table

![updates](https://user-images.githubusercontent.com/916023/108443502-c0d11000-720d-11eb-84e0-78af299ce67b.jpg)

Posts list table

![posts](https://user-images.githubusercontent.com/916023/108443524-cb8ba500-720d-11eb-82f9-91e252154281.jpg)
