### PR TITLE
Change the url updates on WP button link

### DIFF
--- a/revisions-extended/src/plugins/revision-editor/wp-button-modifier/index.js
+++ b/revisions-extended/src/plugins/revision-editor/wp-button-modifier/index.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
+import { subscribe } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -10,32 +11,37 @@ import { useParentPost } from '../../../hooks';
 import { getAllRevisionUrl } from '../../../utils';
 
 /**
- * Module variables
- */
-let wpButtonElement;
-
-/**
  * Returns the WP button element
  *
  * @return {HTMLElement} Html anchor tag.
  */
 const getWPButton = () => {
-	if ( wpButtonElement ) return wpButtonElement;
-
 	return document.querySelector( '.edit-post-fullscreen-mode-close' );
 };
 
 const WPButtonModifier = () => {
+	const [ typeUrl, setTypeUrl ] = useState();
 	const { type } = useParentPost();
 
-	useEffect( () => {
-		if ( ! type ) return;
-		const btn = getWPButton();
+	subscribe( () => {
+		if ( ! typeUrl ) {
+			return;
+		}
 
-		if ( btn ) {
-			btn.href = getAllRevisionUrl( type );
+		const wpButtonElement = getWPButton();
+
+		if ( wpButtonElement || wpButtonElement.href !== typeUrl ) {
+			wpButtonElement.href = typeUrl;
 		}
 	} );
+
+	useEffect( () => {
+		if ( ! type ) {
+			return;
+		}
+
+		setTypeUrl( getAllRevisionUrl( type ) );
+	}, [ type ] );
 
 	return null;
 };

--- a/revisions-extended/src/plugins/revision-editor/wp-button-modifier/index.js
+++ b/revisions-extended/src/plugins/revision-editor/wp-button-modifier/index.js
@@ -30,7 +30,7 @@ const WPButtonModifier = () => {
 
 		const wpButtonElement = getWPButton();
 
-		if ( wpButtonElement || wpButtonElement.href !== typeUrl ) {
+		if ( wpButtonElement && wpButtonElement.href !== typeUrl ) {
 			wpButtonElement.href = typeUrl;
 		}
 	} );


### PR DESCRIPTION
Although I don't know the exact mechanism; it appears as though the `fullscreenmode` feature can be activated by the block editor at different times which causes the current code to update the link but loses the 'battle' as it's again overwritten by later asynchronous updates.

The only way I could figure out how to solve it is to update it using `subscribe` so any updates to the state will trigger the replacement.

 It's not the most performant seeing that we grab a dom reference every `subscribe` call but I don't see another way. I tried stashing the reference but it appears to get detached by Gutenberg.

