### PR TITLE
Tools: Add `wp-env` as a script command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Extended functionality for the WordPress revision system.
 
 1. `npm install`
 1. `npm run setup`
-1. `wp-env start`
+1. `npm run wp-env start`

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"build": "wp-scripts build revisions-extended/src/editor-modifications.js revisions-extended/src/revision-editor.js --output-path=revisions-extended/build/",
 		"start": "wp-scripts start revisions-extended/src/editor-modifications.js revisions-extended/src/revision-editor.js --output-path=revisions-extended/build",
 		"lint:js": "wp-scripts lint-js",
-		"test:unit": "wp-scripts test-unit-js"
+		"test:unit": "wp-scripts test-unit-js",
+		"wp-env": "wp-env"
 	},
 	"devDependencies": {
 		"@wordpress/date": "^3.13.1",


### PR DESCRIPTION
Set up a script alias to the locally installed `wp-env`. If you don't have `wp-env` installed globally, trying to run `wp-env start` results in an error. We can bypass this by adding this command and running it via `npm run …`.