### PR TITLE
Update the __() calls to include text domain.

### DIFF
--- a/revisions-extended/includes/admin.php
+++ b/revisions-extended/includes/admin.php
@@ -168,15 +168,17 @@ function pre_render_updates_subpage() {
 
 		wp_safe_redirect( $redirect );
 	} else {
-		$remove_args = array_filter( (array) filter_input_array(
-			INPUT_GET,
-			array(
-				'action'           => FILTER_DEFAULT,
-				'action2'          => FILTER_DEFAULT,
-				'_wp_http_referer' => FILTER_DEFAULT,
-				'_wpnonce'         => FILTER_DEFAULT,
+		$remove_args = array_filter(
+			(array) filter_input_array(
+				INPUT_GET,
+				array(
+					'action'           => FILTER_DEFAULT,
+					'action2'          => FILTER_DEFAULT,
+					'_wp_http_referer' => FILTER_DEFAULT,
+					'_wpnonce'         => FILTER_DEFAULT,
+				)
 			)
-		) );
+		);
 		$remove_args = array_keys( $remove_args );
 
 		if ( '' === filter_input( INPUT_GET, 's' ) ) {
@@ -206,18 +208,20 @@ function render_updates_subpage() {
 		'error'   => array(),
 	);
 
-	$action_results = array_filter( filter_input_array(
-		INPUT_GET,
-		array(
-			// Be sure to include each of these in `filter_add_removable_query_args` as well.
-			'invalid'       => FILTER_VALIDATE_BOOLEAN,
-			'no_items'      => FILTER_VALIDATE_BOOLEAN,
-			'deleted'       => FILTER_VALIDATE_INT,
-			'not_deleted'   => FILTER_VALIDATE_INT,
-			'published'     => FILTER_VALIDATE_INT,
-			'not_published' => FILTER_VALIDATE_INT,
+	$action_results = array_filter(
+		filter_input_array(
+			INPUT_GET,
+			array(
+				// Be sure to include each of these in `filter_add_removable_query_args` as well.
+				'invalid'       => FILTER_VALIDATE_BOOLEAN,
+				'no_items'      => FILTER_VALIDATE_BOOLEAN,
+				'deleted'       => FILTER_VALIDATE_INT,
+				'not_deleted'   => FILTER_VALIDATE_INT,
+				'published'     => FILTER_VALIDATE_INT,
+				'not_published' => FILTER_VALIDATE_INT,
+			)
 		)
-	) );
+	);
 
 	if ( ! empty( $action_results ) ) {
 		foreach ( $action_results as $result => $count ) {
@@ -582,7 +586,7 @@ function filter_menu_file_for_edit_screen( $file ) {
 /**
  * Add states for posts with updates.
  *
- * @param array $post_states
+ * @param array   $post_states
  * @param WP_Post $post
  *
  * @return mixed

--- a/revisions-extended/includes/cron.php
+++ b/revisions-extended/includes/cron.php
@@ -48,7 +48,7 @@ function schedule_update( $post_id, $post ) {
  * This is hooked to two different actions that provide parameters in different orders. Thus sometimes
  * the first parameter is the WP_Post object, and sometimes the second one is.
  *
- * @param int|WP_Post $revision
+ * @param int|WP_Post              $revision
  * @param WP_Post|\WP_REST_Request
  */
 function unschedule_update( $revision, $revision2 ) {

--- a/revisions-extended/includes/rest-revision-controller.php
+++ b/revisions-extended/includes/rest-revision-controller.php
@@ -32,7 +32,7 @@ class REST_Revision_Controller extends WP_REST_Posts_Controller {
 			array(
 				'args'   => array(
 					'id' => array(
-						'description' => __( 'Unique identifier for the object.' ),
+						'description' => __( 'Unique identifier for the object.', 'revisions-extended' ),
 						'type'        => 'integer',
 					),
 				),
@@ -56,7 +56,7 @@ class REST_Revision_Controller extends WP_REST_Posts_Controller {
 						'force' => array(
 							'type'        => 'boolean',
 							'default'     => false,
-							'description' => __( 'Whether to bypass Trash and force deletion.' ),
+							'description' => __( 'Whether to bypass Trash and force deletion.', 'revisions-extended' ),
 						),
 					),
 				),
@@ -299,11 +299,13 @@ class REST_Revision_Controller extends WP_REST_Posts_Controller {
 
 			if ( $parent && $post_type ) {
 				$links['parent'] = array(
-					'href'       => rest_url( sprintf(
-						'wp/v2/%s/%d',
-						get_post_type_object( $post_type )->get_rest_controller()->rest_base,
-						$parent->ID
-					) ),
+					'href'       => rest_url(
+						sprintf(
+							'wp/v2/%s/%d',
+							get_post_type_object( $post_type )->get_rest_controller()->rest_base,
+							$parent->ID
+						)
+					),
 					'embeddable' => true,
 				);
 			}
@@ -322,7 +324,7 @@ class REST_Revision_Controller extends WP_REST_Posts_Controller {
 
 		$schema['properties']['status']['enum'] = wp_list_pluck( get_revision_statuses(), 'name' );
 		$schema['properties']['parent']         = array(
-			'description' => __( 'The ID for the parent of the object.' ),
+			'description' => __( 'The ID for the parent of the object.', 'revisions-extended' ),
 			'type'        => 'integer',
 			'context'     => array( 'view', 'edit' ),
 		);

--- a/revisions-extended/includes/rest-revisions-controller.php
+++ b/revisions-extended/includes/rest-revisions-controller.php
@@ -242,7 +242,7 @@ class REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 		$schema = parent::get_item_schema();
 
 		$schema['properties']['status'] = array(
-			'description' => __( 'A named status for the object.' ),
+			'description' => __( 'A named status for the object.', 'revisions-extended' ),
 			'type'        => 'string',
 			'enum'        => wp_list_pluck( get_revision_statuses(), 'name' ),
 			'context'     => array( 'view', 'edit' ),
@@ -315,11 +315,13 @@ class REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 			if ( $parent && $post_type ) {
 				$response->add_link(
 					'parent',
-					rest_url( sprintf(
-						'wp/v2/%s/%d',
-						get_post_type_object( $post_type )->rest_base,
-						$parent->ID
-					) ),
+					rest_url(
+						sprintf(
+							'wp/v2/%s/%d',
+							get_post_type_object( $post_type )->rest_base,
+							$parent->ID
+						)
+					),
 					array(
 						'embeddable' => true,
 					)

--- a/revisions-extended/includes/revision-list-table.php
+++ b/revisions-extended/includes/revision-list-table.php
@@ -223,7 +223,7 @@ class Revision_List_Table extends WP_List_Table {
 			<label class="screen-reader-text" for="cb-select-<?php echo esc_attr( $post->ID ); ?>">
 				<?php
 				/* translators: %s: Post title. */
-				printf( __( 'Select %s' ), _draft_or_post_title() );
+				printf( __( 'Select %s', 'revisions-extended' ), _draft_or_post_title() );
 				?>
 			</label>
 			<input
@@ -238,7 +238,7 @@ class Revision_List_Table extends WP_List_Table {
 				<?php
 				printf(
 				/* translators: %s: Post title. */
-					__( '&#8220;%s&#8221; is locked' ),
+					__( '&#8220;%s&#8221; is locked', 'revisions-extended' ),
 					_draft_or_post_title( $post )
 				);
 				?>
@@ -266,7 +266,7 @@ class Revision_List_Table extends WP_List_Table {
 				$lock_holder   = get_userdata( $lock_holder );
 				$locked_avatar = get_avatar( $lock_holder->ID, 18 );
 				/* translators: %s: User's display name. */
-				$locked_text = esc_html( sprintf( __( '%s is currently editing' ), $lock_holder->display_name ) );
+				$locked_text = esc_html( sprintf( __( '%s is currently editing', 'revisions-extended' ), $lock_holder->display_name ) );
 			} else {
 				$locked_avatar = '';
 				$locked_text   = '';
@@ -284,7 +284,7 @@ class Revision_List_Table extends WP_List_Table {
 				'<a class="row-title" href="%1$s" aria-label="%2$s">%3$s</a>',
 				esc_url( get_edit_revision_link( $post->ID ) ),
 				/* translators: %s: Post title. */
-				esc_attr( sprintf( __( '&#8220;%s&#8221; (Edit)' ), $title ) ),
+				esc_attr( sprintf( __( '&#8220;%s&#8221; (Edit)', 'revisions-extended' ), $title ) ),
 				$title
 			);
 		} else {
@@ -337,7 +337,7 @@ class Revision_List_Table extends WP_List_Table {
 				'<a class="row-title" href="%1$s" aria-label="%2$s">%3$s</a>',
 				esc_url( get_edit_post_link( $parent ) ),
 				/* translators: %s: Post title. */
-				esc_attr( sprintf( __( '&#8220;%s&#8221; (Edit)' ), $title ) ),
+				esc_attr( sprintf( __( '&#8220;%s&#8221; (Edit)', 'revisions-extended' ), $title ) ),
 				$title
 			);
 		} else {
@@ -404,9 +404,9 @@ class Revision_List_Table extends WP_List_Table {
 					/* translators: 1: Post date, 2: Post time. */
 					esc_html__( '%1$s at %2$s', 'revisions-extended' ),
 					/* translators: Post date format. See https://www.php.net/manual/datetime.format.php */
-					get_the_time( __( 'Y/m/d' ), $post ),
+					get_the_time( __( 'Y/m/d', 'revisions-extended' ), $post ),
 					/* translators: Post time format. See https://www.php.net/manual/datetime.format.php */
-					get_the_time( __( 'g:i a' ), $post )
+					get_the_time( __( 'g:i a', 'revisions-extended' ), $post )
 				);
 				break;
 		}
@@ -424,9 +424,9 @@ class Revision_List_Table extends WP_List_Table {
 			/* translators: 1: Post date, 2: Post time. */
 			__( '%1$s at %2$s', 'revisions-extended' ),
 			/* translators: Post date format. See https://www.php.net/manual/datetime.format.php */
-			get_the_modified_time( __( 'Y/m/d' ), $post ),
+			get_the_modified_time( __( 'Y/m/d', 'revisions-extended' ), $post ),
 			/* translators: Post time format. See https://www.php.net/manual/datetime.format.php */
-			get_the_modified_time( __( 'g:i a' ), $post )
+			get_the_modified_time( __( 'g:i a', 'revisions-extended' ), $post )
 		);
 	}
 

--- a/revisions-extended/includes/revision.php
+++ b/revisions-extended/includes/revision.php
@@ -99,13 +99,16 @@ function get_revisions_by_parent_type( $parent_post_type, $args = array(), $wp_q
 	global $wpdb;
 
 	// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-	$valid_ids = $wpdb->get_col( $wpdb->prepare( "
+	$valid_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"
 		SELECT revisions.ID
 		FROM {$wpdb->posts} revisions
 			JOIN {$wpdb->posts} parents ON parents.ID = revisions.post_parent AND parents.post_type = %s
 		WHERE revisions.post_type = 'revision' AND revisions.post_status = 'future'",
-		$parent_post_type
-	) );
+			$parent_post_type
+		)
+	);
 
 	// If post__in gets an empty array, WP_Query will return all posts.
 	if ( empty( $valid_ids ) ) {
@@ -147,11 +150,11 @@ function put_post_revision( $post = null, $autosave = false ) {
 	}
 
 	if ( ! $post || empty( $post['ID'] ) ) {
-		return new WP_Error( 'invalid_post', __( 'Invalid post ID.' ) );
+		return new WP_Error( 'invalid_post', __( 'Invalid post ID.', 'revisions-extended' ) );
 	}
 
 	if ( isset( $post['post_type'] ) && 'revision' === $post['post_type'] ) {
-		return new WP_Error( 'post_type', __( 'Cannot create a revision of a revision' ) );
+		return new WP_Error( 'post_type', __( 'Cannot create a revision of a revision', 'revisions-extended' ) );
 	}
 
 	// Begin changes from Core.

--- a/revisions-extended/src/components/confirm-window/index.js
+++ b/revisions-extended/src/components/confirm-window/index.js
@@ -33,10 +33,13 @@ const ConfirmWindow = ( { title, notice, links } ) => {
 			{ notice }
 			<div className="confirm-window__content">
 				<Text variant="title.small" as="h3">
-					{ __( 'Next Steps' ) }
+					{ __( 'Next Steps', 'revisions-extended' ) }
 				</Text>
 				<Text as="h4">
-					{ __( 'Select one of the following actions:' ) }
+					{ __(
+						'Select one of the following actions:',
+						'revisions-extended'
+					) }
 				</Text>
 				<ul>
 					{ links.map( ( i ) => (

--- a/revisions-extended/src/plugins/editor-modifications/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/index.js
@@ -24,7 +24,9 @@ const MainPlugin = () => {
 
 	return (
 		<ErrorBoundary>
-			<InterfaceProvider btnText={ __( 'Create update' ) }>
+			<InterfaceProvider
+				btnText={ __( 'Create update', 'revisions-extended' ) }
+			>
 				<TypesProvider>
 					<UpdateButtonModifier />
 					<PluginPostStatusInfo />

--- a/revisions-extended/src/plugins/editor-modifications/plugin-post-status-info/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/plugin-post-status-info/index.js
@@ -27,7 +27,7 @@ const PluginPostStatusInfo = () => {
 	return (
 		<PostStatusInfo>
 			<CheckboxControl
-				label={ __( 'Create future update' ) }
+				label={ __( 'Create future update', 'revisions-extended' ) }
 				checked={ shouldIntercept }
 				onChange={ setShouldIntercept }
 			/>

--- a/revisions-extended/src/plugins/revision-editor/document-settings-panel/post-status-publish-checkbox.js
+++ b/revisions-extended/src/plugins/revision-editor/document-settings-panel/post-status-publish-checkbox.js
@@ -7,7 +7,7 @@ import { CheckboxControl } from '@wordpress/components';
 const PostStatusPublishCheckbox = ( { toggled, onToggle } ) => {
 	return (
 		<CheckboxControl
-			label={ __( 'Publish immediately' ) }
+			label={ __( 'Publish immediately', 'revisions-extended' ) }
 			checked={ toggled }
 			onChange={ onToggle }
 		/>

--- a/revisions-extended/src/plugins/revision-editor/document-settings-panel/post-status-trash-button.js
+++ b/revisions-extended/src/plugins/revision-editor/document-settings-panel/post-status-trash-button.js
@@ -56,7 +56,7 @@ const PostStatusTrashButton = ( { onDelete, id } ) => {
 			isDestructive
 			isBusy={ isBusy }
 		>
-			{ __( 'Delete permanently' ) }
+			{ __( 'Delete permanently', 'revisions-extended' ) }
 		</Button>
 	);
 };

--- a/revisions-extended/src/plugins/revision-editor/index.js
+++ b/revisions-extended/src/plugins/revision-editor/index.js
@@ -41,7 +41,9 @@ const PluginWrapper = () => {
 
 	return (
 		<ErrorBoundary>
-			<InterfaceProvider btnText={ __( 'Publish' ) }>
+			<InterfaceProvider
+				btnText={ __( 'Publish', 'revisions-extended' ) }
+			>
 				<ParentPostProvider links={ savedPost._links }>
 					<TypesProvider>
 						<DocumentSettingsPanel />

--- a/revisions-extended/src/plugins/revision-editor/revision-indicator/index.js
+++ b/revisions-extended/src/plugins/revision-editor/revision-indicator/index.js
@@ -29,8 +29,8 @@ const RevisionIndicator = () => {
 
 	const getRevisionType =
 		savedPost.status === POST_STATUS_SCHEDULED
-			? __( 'scheduled' )
-			: __( 'pending' );
+			? __( 'scheduled', 'revisions-extended' )
+			: __( 'pending', 'revisions-extended' );
 
 	useEffect( () => {
 		if ( ! parentType || ! loadedTypes ) return;
@@ -38,19 +38,23 @@ const RevisionIndicator = () => {
 		const notes = [
 			sprintf(
 				// translators: %s: revision type.
-				__( 'You are currently editing a <b>%s update</b>.' ),
+				__(
+					'You are currently editing a <b>%s update</b>.',
+					'revisions-extended'
+				),
 				getRevisionType
 			),
 			sprintf(
 				// translators: %1$s: url %2$s: post type.
-				__( '[ <a href="%1$s">Edit %2$s</a>' ),
+				__( '[ <a href="%1$s">Edit %2$s</a>', 'revisions-extended' ),
 				getEditUrl( savedPost.parent ),
 				getTypeInfo(
 					`${ parentType }.labels.singular_name`
 				).toLowerCase()
 			),
 			` | <a href="${ getCompareLink( savedPost.id ) }" />${ __(
-				'See changes'
+				'See changes',
+				'revisions-extended'
 			) }</a> ]`,
 		];
 

--- a/revisions-extended/src/plugins/revision-editor/update-button-modifier/index.js
+++ b/revisions-extended/src/plugins/revision-editor/update-button-modifier/index.js
@@ -38,7 +38,10 @@ const UpdateButtonModifier = () => {
 		if ( ! didPostSaveRequestSucceed() ) {
 			dispatch( 'core/notices' ).createNotice(
 				'error',
-				__( 'Error saving update before publish.' )
+				__(
+					'Error saving update before publish.',
+					'revisions-extended'
+				)
 			);
 			return;
 		}
@@ -52,7 +55,7 @@ const UpdateButtonModifier = () => {
 		if ( error ) {
 			dispatch( 'core/notices' ).createNotice(
 				'error',
-				__( 'Error publishing revision.' )
+				__( 'Error publishing revision.', 'revisions-extended' )
 			);
 		}
 	};
@@ -68,17 +71,20 @@ const UpdateButtonModifier = () => {
 	if ( showSuccess ) {
 		return (
 			<ConfirmWindow
-				title={ __( 'Revisions Extended' ) }
+				title={ __( 'Revisions Extended', 'revisions-extended' ) }
 				notice={
 					<Notice status="success" isDismissible={ false }>
-						{ __( 'Successfully published your update.' ) }
+						{ __(
+							'Successfully published your update.',
+							'revisions-extended'
+						) }
 					</Notice>
 				}
 				links={ [
 					{
 						text: sprintf(
 							// translators: %s: post type.
-							__( 'View published %s.' ),
+							__( 'View published %s.', 'revisions-extended' ),
 							getTypeInfo(
 								`${ parentType }.labels.singular_name`
 							).toLowerCase()
@@ -88,7 +94,7 @@ const UpdateButtonModifier = () => {
 					{
 						text: sprintf(
 							// translators: %s: post type.
-							__( 'Edit original %s.' ),
+							__( 'Edit original %s.', 'revisions-extended' ),
 							getTypeInfo(
 								`${ parentType }.labels.singular_name`
 							).toLowerCase()
@@ -98,7 +104,7 @@ const UpdateButtonModifier = () => {
 					{
 						text: sprintf(
 							// translators: %s: post type.
-							__( 'View all %s updates.' ),
+							__( 'View all %s updates.', 'revisions-extended' ),
 							getTypeInfo(
 								`${ parentType }.labels.singular_name`
 							).toLowerCase()

--- a/revisions-extended/src/utils.js
+++ b/revisions-extended/src/utils.js
@@ -66,7 +66,7 @@ export const getStatusDisplay = ( postStatus, date ) => {
 	if ( POST_STATUS_SCHEDULED === postStatus ) {
 		return sprintf(
 			// translators: %s: formatted date
-			__( 'Scheduled for %s' ),
+			__( 'Scheduled for %s', 'revisions-extended' ),
 			getShortenedFormattedDate( date )
 		);
 	}


### PR DESCRIPTION
This PR adds our plugin's text-domain in all `__()` references. 

As a side effect, `format:php` caught a few changes that I've left in seeing that they are most likely harmless and we don't have any other pull requests open.

Addressed: #61 