### PR TITLE
Add wrapper function to check update support

### DIFF
--- a/revisions-extended/includes/admin.php
+++ b/revisions-extended/includes/admin.php
@@ -8,6 +8,7 @@ use function RevisionsExtended\get_assets_path;
 use function RevisionsExtended\get_build_asset_info;
 use function RevisionsExtended\get_includes_path;
 use function RevisionsExtended\get_views_path;
+use function RevisionsExtended\Revision\post_type_supports_updates;
 use function RevisionsExtended\Revision\get_post_revisions;
 use function RevisionsExtended\Revision\update_post_from_revision;
 
@@ -87,7 +88,7 @@ function enqueue_block_editor_assets() {
 	$handles = array();
 	if ( 'revision' === $post_type ) {
 		$handles[] = 'revision-editor';
-	} elseif ( post_type_supports( $post_type, 'revisions' ) ) {
+	} elseif ( post_type_supports_updates( $post_type ) ) {
 		$handles[] = 'editor-modifications';
 	}
 
@@ -600,7 +601,7 @@ function filter_display_post_states( $post_states, $post ) {
 		if ( 'publish' !== get_post_status( $parent ) ) {
 			$post_states['suspended'] = _x( 'Suspended', 'post status', 'revisions-extended' );
 		}
-	} elseif ( post_type_supports( get_post_type( $post ), 'revisions' ) ) {
+	} elseif ( post_type_supports_updates( get_post_type( $post ) ) ) {
 		$args      = array(
 			'post_status' => 'future',
 		);

--- a/revisions-extended/includes/revision.php
+++ b/revisions-extended/includes/revision.php
@@ -38,6 +38,19 @@ function modify_revision_post_type( $post_type, $post_type_object ) {
 }
 
 /**
+ * Check if a given post type should support updates.
+ *
+ * @param string $post_type
+ *
+ * @return bool True if the post type supports updates.
+ */
+function post_type_supports_updates( $post_type ) {
+	$exceptions = array( 'wp_template' );
+
+	return post_type_supports( $post_type, 'revisions' ) && ! in_array( $post_type, $exceptions, true );
+}
+
+/**
  * Returns revisions of specified post.
  *
  * Specify a value for $args['post_status'] to get other types of revisions.

--- a/revisions-extended/index.php
+++ b/revisions-extended/index.php
@@ -13,6 +13,7 @@
 namespace RevisionsExtended;
 
 use RevisionsExtended\REST_Revisions_Controller;
+use function RevisionsExtended\Revision\post_type_supports_updates;
 
 defined( 'WPINC' ) || die();
 
@@ -105,7 +106,7 @@ function get_build_asset_info( $handle ) {
  */
 function initialize_rest_routes() {
 	foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
-		if ( post_type_supports( $post_type->name, 'revisions' ) ) {
+		if ( post_type_supports_updates( $post_type->name ) ) {
 			$controller = new REST_Revisions_Controller( $post_type->name );
 			$controller->register_routes();
 		}


### PR DESCRIPTION
The main criteria for whether a post type should have updates is whether or not it already supports the built in revisions system. However, since we now have an exception, where there's a post type that does support revisions, but we don't (currently) want it to support updates, we need our own checking function.

Fixes #78 