### PR TITLE
Show publish immediately if parent is published.

### DIFF
--- a/revisions-extended/src/plugins/revision-editor/document-settings-panel/index.js
+++ b/revisions-extended/src/plugins/revision-editor/document-settings-panel/index.js
@@ -17,7 +17,13 @@ import PostSchedule from './post-schedule';
 import PostStatusTrashButton from './post-status-trash-button';
 import PostStatusPublishCheckbox from './post-status-publish-checkbox';
 
-import { useInterface, useRevision, usePost } from '../../../hooks';
+import {
+	useInterface,
+	useRevision,
+	usePost,
+	useParentPost,
+} from '../../../hooks';
+import { WP_PUBLISH_STATUS } from '../../../settings';
 
 import { GUTENBERG_PLUGIN_NAMESPACE } from '../index';
 
@@ -32,6 +38,7 @@ const DocumentSettingsPanel = () => {
 	const { shouldIntercept, setShouldIntercept } = useInterface();
 	const { trash } = useRevision();
 	const { getEditedPostAttribute } = usePost();
+	const { status: parentStatus } = useParentPost();
 
 	useEffect( () => {
 		// Hide the default panel;
@@ -58,12 +65,14 @@ const DocumentSettingsPanel = () => {
 			<PanelRow>
 				<PostSchedule />
 			</PanelRow>
-			<PanelRow>
-				<PostStatusPublishCheckbox
-					toggled={ shouldIntercept }
-					onToggle={ setShouldIntercept }
-				/>
-			</PanelRow>
+			{ parentStatus === WP_PUBLISH_STATUS && (
+				<PanelRow>
+					<PostStatusPublishCheckbox
+						toggled={ shouldIntercept }
+						onToggle={ setShouldIntercept }
+					/>
+				</PanelRow>
+			) }
 			<PanelRow>
 				<PostStatusTrashButton
 					id={ getEditedPostAttribute( 'id' ) }

--- a/revisions-extended/src/settings.js
+++ b/revisions-extended/src/settings.js
@@ -1,3 +1,4 @@
 export const POST_STATUS_SCHEDULED = 'future';
 export const POST_STATUS_PENDING = 'pending';
 export const GUTENBERG_EDITOR_STORE = 'core/editor';
+export const WP_PUBLISH_STATUS = 'publish';


### PR DESCRIPTION
This PR hides the "Publish Immediately" button if the parent post is set to published.

Fixes: #92 