### PR TITLE
Update some editor UI wording

### DIFF
--- a/revisions-extended/src/plugins/editor-modifications/create-sidebar/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/create-sidebar/index.js
@@ -122,7 +122,7 @@ const CreateSidebar = () => {
 	return (
 		<PluginSidebar
 			name={ CREATE_SIDEBAR_NAME }
-			title={ __( 'Schedule Update', 'revisions-extended' ) }
+			title={ __( 'Save for later', 'revisions-extended' ) }
 			icon={ calendar }
 			isPinnable={ false }
 		>
@@ -174,7 +174,7 @@ const CreateSidebar = () => {
 									} }
 								>
 									{ __(
-										'Create update',
+										'Save update',
 										'revisions-extended'
 									) }
 								</Button>

--- a/revisions-extended/src/plugins/editor-modifications/create-success-window/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/create-success-window/index.js
@@ -30,7 +30,7 @@ const CreateConfirmWindow = () => {
 
 	return (
 		<ConfirmWindow
-			title="Revisions Extended"
+			title={ __( 'Update saved', 'revisions-extended' ) }
 			notice={
 				<Notice status="success" isDismissible={ false }>
 					{ newRevision.status === POST_STATUS_SCHEDULED ? (
@@ -58,7 +58,7 @@ const CreateConfirmWindow = () => {
 			links={ [
 				{
 					text: __(
-						'Continue editing your update.',
+						'Continue editing your update',
 						'revisions-extended'
 					),
 					href: getEditUrl( newRevision.id ),
@@ -66,7 +66,7 @@ const CreateConfirmWindow = () => {
 				{
 					text: sprintf(
 						// translators: %s: post type.
-						__( 'Edit original %s.', 'revisions-extended' ),
+						__( 'Edit original %s', 'revisions-extended' ),
 						getTypeInfo(
 							`${ savedPost.type }.labels.singular_name`
 						).toLowerCase()
@@ -76,7 +76,7 @@ const CreateConfirmWindow = () => {
 				{
 					text: sprintf(
 						// translators: %s: post type.
-						__( 'View all %s updates.', 'revisions-extended' ),
+						__( 'View all %s updates', 'revisions-extended' ),
 						getTypeInfo(
 							`${ savedPost.type }.labels.singular_name`
 						).toLowerCase()

--- a/revisions-extended/src/plugins/editor-modifications/update-dropdown-button/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/update-dropdown-button/index.js
@@ -29,7 +29,7 @@ const UpdateDropdownButton = () => {
 					<MenuGroup>
 						<MenuItem
 							info={ __(
-								'Publish on a specific date',
+								'Schedule update for a specific time',
 								'revisions-extended'
 							) }
 							onClick={ () => {
@@ -51,7 +51,7 @@ const UpdateDropdownButton = () => {
 								);
 							} }
 						>
-							{ __( 'Schedule update', 'revisions-extended' ) }
+							{ __( 'Save for later', 'revisions-extended' ) }
 						</MenuItem>
 					</MenuGroup>
 				) }


### PR DESCRIPTION
* Use "Save for later" instead of "Schedule update". This seems like it might be more intuitive when discovering the option, and will be more flexible when other statuses are added later
* Use "Save update" instead of "Create update".
* Remove full stops from "Next steps" links