### PR TITLE
Disable the publish button if not published.

### DIFF
--- a/revisions-extended/src/plugins/revision-editor/index.js
+++ b/revisions-extended/src/plugins/revision-editor/index.js
@@ -9,6 +9,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { ErrorBoundary } from '../../components';
 import DocumentSettingsPanel from './document-settings-panel';
 import RevisionIndicator from './revision-indicator';
+import NotPublishableIndicator from './not-publishable-indicator';
 import WPButtonModifier from './wp-button-modifier';
 import TabTextModifier from './tab-text-modifier';
 import UpdateDropdownButton from './update-dropdown-button';
@@ -47,6 +48,7 @@ const PluginWrapper = () => {
 						<UpdateDropdownButton />
 						<DocumentSettingsPanel />
 						<RevisionIndicator />
+						<NotPublishableIndicator />
 						<WPButtonModifier />
 						<TabTextModifier />
 						<PublishSuccessWindow />

--- a/revisions-extended/src/plugins/revision-editor/not-publishable-indicator/index.js
+++ b/revisions-extended/src/plugins/revision-editor/not-publishable-indicator/index.js
@@ -46,7 +46,7 @@ const NotPublishableIndicator = () => {
 						),
 						typeInfo
 					),
-				].join( '' )
+				].join( ' ' )
 			);
 		}
 	}, [ type, loadedTypes ] );

--- a/revisions-extended/src/plugins/revision-editor/not-publishable-indicator/index.js
+++ b/revisions-extended/src/plugins/revision-editor/not-publishable-indicator/index.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+
+/**
+ * WordPress Dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+
+import { useParentPost, useTypes } from '../../../hooks';
+import { WP_PUBLISH_STATUS } from '../../../settings';
+
+const NotPublishableIndicator = () => {
+	const { type, status } = useParentPost();
+	const { loaded: loadedTypes, getTypeInfo } = useTypes();
+
+	useEffect( () => {
+		if ( ! type || ! loadedTypes ) return;
+
+		if ( status !== WP_PUBLISH_STATUS ) {
+			const typeInfo = getTypeInfo(
+				`${ type }.labels.singular_name`
+			).toLowerCase();
+
+			dispatch( 'core/notices' ).createErrorNotice(
+				[
+					sprintf(
+						// translators: %s is the singular label of a post type.
+						__(
+							'The original %s is not published.',
+							'revisions-extended'
+						),
+						typeInfo
+					),
+					sprintf(
+						// translators: %s is the singular label of a post type.
+						__(
+							"You can edit this update but it can't be published until the original %s is live.",
+							'revisions-extended'
+						),
+						typeInfo
+					),
+				].join( '' )
+			);
+		}
+	}, [ type, loadedTypes ] );
+
+	return null;
+};
+
+export default NotPublishableIndicator;

--- a/revisions-extended/src/plugins/revision-editor/update-dropdown-button/index.js
+++ b/revisions-extended/src/plugins/revision-editor/update-dropdown-button/index.js
@@ -10,13 +10,20 @@ import { MenuGroup, MenuItem } from '@wordpress/components';
  * Internal dependencies
  */
 import { DropDownButton } from '../../../components';
-import { usePost, useInterface, useRevision } from '../../../hooks';
+import {
+	usePost,
+	useInterface,
+	useRevision,
+	useParentPost,
+} from '../../../hooks';
 import { insertButton } from '../../../utils';
+import { WP_PUBLISH_STATUS } from '../../../settings';
 
 const UpdateDropdownButton = () => {
 	const { savedPost, didPostSaveRequestSucceed, savePost } = usePost();
 	const { publish } = useRevision();
 	const { setState } = useInterface();
+	const { status: parentStatus } = useParentPost();
 
 	const _savePost = async () => {
 		// Save the post first
@@ -63,6 +70,7 @@ const UpdateDropdownButton = () => {
 								onClose();
 								await _savePost();
 							} }
+							disabled={ parentStatus !== WP_PUBLISH_STATUS }
 						>
 							{ __( 'Publish now', 'revisions-extended' ) }
 						</MenuItem>

--- a/revisions-extended/src/settings.js
+++ b/revisions-extended/src/settings.js
@@ -3,3 +3,4 @@ export const POST_STATUS_PENDING = 'pending';
 export const GUTENBERG_EDITOR_STORE = 'core/editor';
 export const GUTENBERG_EDIT_POST_STORE = 'core/edit-post';
 export const GUTENBERG_INTERFACE_STORE = 'core/interface';
+export const WP_PUBLISH_STATUS = 'publish';


### PR DESCRIPTION
This PR replaces #93. 

In order to inform the user that the update is not publishable this pr:
- Disables the publish button if parent is not published
- Add's an error message if the parent is not published

Since this shouldn't be a critical flow, I think this does a fair job setting the context. I chose to use an error notice to make sure it's acknowledged.


## Screenshot

![](https://d.pr/i/EvO7bE.png)