### PR TITLE
Redirect to post updates list page on delete.

### DIFF
--- a/revisions-extended/src/plugins/revision-editor/document-settings-panel/index.js
+++ b/revisions-extended/src/plugins/revision-editor/document-settings-panel/index.js
@@ -16,7 +16,7 @@ import { PanelRow } from '@wordpress/components';
 import PostSchedule from './post-schedule';
 import PostStatusTrashButton from './post-status-trash-button';
 
-import { useRevision, usePost } from '../../../hooks';
+import { useRevision, usePost, useParentPost } from '../../../hooks';
 
 import { GUTENBERG_PLUGIN_NAMESPACE } from '../index';
 
@@ -30,6 +30,7 @@ const PANEL_NAME = 'scheduled-revisions';
 const DocumentSettingsPanel = () => {
 	const { trash } = useRevision();
 	const { getEditedPostAttribute } = usePost();
+	const { type: parentType } = useParentPost();
 
 	useEffect( () => {
 		// Hide the default panel;
@@ -59,6 +60,7 @@ const DocumentSettingsPanel = () => {
 			<PanelRow>
 				<PostStatusTrashButton
 					id={ getEditedPostAttribute( 'id' ) }
+					parentType={ parentType }
 					onDelete={ trash }
 				/>
 			</PanelRow>

--- a/revisions-extended/src/plugins/revision-editor/document-settings-panel/post-status-trash-button.js
+++ b/revisions-extended/src/plugins/revision-editor/document-settings-panel/post-status-trash-button.js
@@ -9,7 +9,12 @@ import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
-const PostStatusTrashButton = ( { onDelete, id } ) => {
+/**
+ * Internal dependencies
+ */
+import { getAllRevisionUrl } from '../../../utils';
+
+const PostStatusTrashButton = ( { onDelete, id, parentType } ) => {
 	const [ isBusy, setBusy ] = useState( false );
 
 	const deleteUpdate = async () => {
@@ -29,11 +34,7 @@ const PostStatusTrashButton = ( { onDelete, id } ) => {
 		}
 
 		if ( data ) {
-			if ( document.referrer.length > 0 ) {
-				window.location.href = document.referrer;
-			} else {
-				window.location.reload();
-			}
+			window.location.href = getAllRevisionUrl( parentType );
 		}
 	};
 


### PR DESCRIPTION
This PR redirects to the `postType`'s update list on delete.

Fixes: #99 