### PR TITLE
Reintroduce pending status and also add draft status for revisions

### DIFF
--- a/revisions-extended/includes/admin.php
+++ b/revisions-extended/includes/admin.php
@@ -8,6 +8,7 @@ use function RevisionsExtended\get_assets_path;
 use function RevisionsExtended\get_build_asset_info;
 use function RevisionsExtended\get_includes_path;
 use function RevisionsExtended\get_views_path;
+use function RevisionsExtended\Post_Status\get_revision_status_slugs;
 use function RevisionsExtended\Revision\post_type_supports_updates;
 use function RevisionsExtended\Revision\get_post_revisions;
 use function RevisionsExtended\Revision\update_post_from_revision;
@@ -661,7 +662,7 @@ function filter_display_post_states( $post_states, $post ) {
 		}
 	} elseif ( post_type_supports_updates( get_post_type( $post ) ) ) {
 		$args      = array(
-			'post_status' => 'future',
+			'post_status' => get_revision_status_slugs(),
 		);
 		$revisions = get_post_revisions( $post, $args );
 

--- a/revisions-extended/includes/capabilities.php
+++ b/revisions-extended/includes/capabilities.php
@@ -2,7 +2,7 @@
 
 namespace RevisionsExtended\Capabilities;
 
-use function RevisionsExtended\Post_Status\get_revision_statuses;
+use function RevisionsExtended\Post_Status\get_revision_status_slugs;
 
 defined( 'WPINC' ) || die();
 
@@ -25,7 +25,7 @@ function map_meta_caps( $caps, $cap, $user_id, $args ) {
 	if ( in_array( $cap, array( 'delete_post', 'edit_post', 'read_post' ), true ) ) {
 		$post              = get_post( $args[0] );
 		$status            = get_post_status( $post );
-		$revision_statuses = wp_list_pluck( get_revision_statuses(), 'name' );
+		$revision_statuses = get_revision_status_slugs();
 
 		if ( $post && 'revision' === get_post_type( $post ) && in_array( $status, $revision_statuses, true ) ) {
 			$revision_object = get_post_type_object( 'revision' );

--- a/revisions-extended/includes/capabilities.php
+++ b/revisions-extended/includes/capabilities.php
@@ -2,7 +2,7 @@
 
 namespace RevisionsExtended\Capabilities;
 
-use function RevisionsExtended\Post_Status\get_revision_status_slugs;
+use function RevisionsExtended\Post_Status\validate_revision_status;
 
 defined( 'WPINC' ) || die();
 
@@ -23,11 +23,10 @@ add_filter( 'map_meta_cap', __NAMESPACE__ . '\map_meta_caps', 10, 4 );
  */
 function map_meta_caps( $caps, $cap, $user_id, $args ) {
 	if ( in_array( $cap, array( 'delete_post', 'edit_post', 'read_post' ), true ) ) {
-		$post              = get_post( $args[0] );
-		$status            = get_post_status( $post );
-		$revision_statuses = get_revision_status_slugs();
+		$post   = get_post( $args[0] );
+		$status = get_post_status( $post );
 
-		if ( $post && 'revision' === get_post_type( $post ) && in_array( $status, $revision_statuses, true ) ) {
+		if ( $post && 'revision' === get_post_type( $post ) && validate_revision_status( $status ) ) {
 			$revision_object = get_post_type_object( 'revision' );
 			$parent          = get_post( $post->post_parent );
 			$parent_object   = get_post_type_object( get_post_type( $parent ) );

--- a/revisions-extended/includes/post-status.php
+++ b/revisions-extended/includes/post-status.php
@@ -28,6 +28,15 @@ function get_revision_statuses() {
 }
 
 /**
+ * Get an array of revision-specific post status slugs.
+ *
+ * @return array
+ */
+function get_revision_status_slugs() {
+	return wp_list_pluck( get_revision_statuses(), 'name' );
+}
+
+/**
  * Check if a given status is a valid revision status.
  *
  * Note that this does not include the 'inherit' status used by the Core revision system.

--- a/revisions-extended/includes/post-status.php
+++ b/revisions-extended/includes/post-status.php
@@ -46,7 +46,7 @@ function get_revision_status_slugs() {
  * @return bool
  */
 function validate_revision_status( $status ) {
-	$statuses = wp_list_pluck( get_revision_statuses(), 'name' );
+	$status_slugs = get_revision_status_slugs();
 
-	return in_array( $status, $statuses, true );
+	return in_array( $status, $status_slugs, true );
 }

--- a/revisions-extended/includes/post-status.php
+++ b/revisions-extended/includes/post-status.php
@@ -20,7 +20,9 @@ function get_revision_statuses() {
 	return array_intersect_key(
 		$stati,
 		array(
-			'future' => true,
+			'draft'   => true,
+			'future'  => true,
+			'pending' => true,
 		)
 	);
 }

--- a/revisions-extended/includes/rest-revision-controller.php
+++ b/revisions-extended/includes/rest-revision-controller.php
@@ -4,7 +4,7 @@ namespace RevisionsExtended;
 
 use WP_Error, WP_Post, WP_Post_Type;
 use WP_REST_Posts_Controller, WP_REST_Revisions_Controller, WP_REST_Request, WP_REST_Response, WP_REST_Server;
-use function RevisionsExtended\Post_Status\get_revision_statuses;
+use function RevisionsExtended\Post_Status\get_revision_status_slugs;
 use function RevisionsExtended\Post_Status\validate_revision_status;
 use function RevisionsExtended\Revision\update_post_from_revision;
 
@@ -104,7 +104,7 @@ class REST_Revision_Controller extends WP_REST_Posts_Controller {
 
 		$parent_endpoint_args = parent::get_endpoint_args_for_item_schema( $method );
 
-		$parent_endpoint_args['status']['enum'] = wp_list_pluck( get_revision_statuses(), 'name' );
+		$parent_endpoint_args['status']['enum'] = get_revision_status_slugs();
 
 		return array_intersect_key( $parent_endpoint_args, array_fill_keys( $revision_fields, '' ) );
 	}
@@ -322,7 +322,7 @@ class REST_Revision_Controller extends WP_REST_Posts_Controller {
 	public function get_item_schema() {
 		$schema = parent::get_item_schema();
 
-		$schema['properties']['status']['enum'] = wp_list_pluck( get_revision_statuses(), 'name' );
+		$schema['properties']['status']['enum'] = get_revision_status_slugs();
 		$schema['properties']['parent']         = array(
 			'description' => __( 'The ID for the parent of the object.', 'revisions-extended' ),
 			'type'        => 'integer',

--- a/revisions-extended/includes/rest-revisions-controller.php
+++ b/revisions-extended/includes/rest-revisions-controller.php
@@ -4,7 +4,7 @@ namespace RevisionsExtended;
 
 use WP_Error, WP_Post;
 use WP_REST_Controller, WP_REST_Posts_Controller, WP_REST_Revisions_Controller, WP_REST_Request, WP_REST_Response, WP_REST_Server;
-use function RevisionsExtended\Post_Status\get_revision_statuses;
+use function RevisionsExtended\Post_Status\get_revision_status_slugs;
 use function RevisionsExtended\Revision\put_post_revision;
 
 defined( 'WPINC' ) || die();
@@ -110,7 +110,7 @@ class REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 
 		$parent_endpoint_args = $this->parent_controller->get_endpoint_args_for_item_schema( $method );
 
-		$parent_endpoint_args['status']['enum'] = wp_list_pluck( get_revision_statuses(), 'name' );
+		$parent_endpoint_args['status']['enum'] = get_revision_status_slugs();
 
 		return array_intersect_key( $parent_endpoint_args, array_fill_keys( $revision_fields, '' ) );
 	}
@@ -257,7 +257,7 @@ class REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 		$schema['properties']['status'] = array(
 			'description' => __( 'A named status for the object.', 'revisions-extended' ),
 			'type'        => 'string',
-			'enum'        => wp_list_pluck( get_revision_statuses(), 'name' ),
+			'enum'        => get_revision_status_slugs(),
 			'context'     => array( 'view', 'edit' ),
 		);
 
@@ -277,7 +277,7 @@ class REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 			'description' => __( 'Limit result set to revisions assigned one or more statuses.', 'revisions-extended' ),
 			'type'        => 'array',
 			'items'       => array(
-				'enum' => array_merge( array( 'any' ), wp_list_pluck( get_revision_statuses(), 'name' ) ),
+				'enum' => array_merge( array( 'any' ), get_revision_status_slugs() ),
 				'type' => 'string',
 			),
 		);
@@ -299,7 +299,7 @@ class REST_Revisions_Controller extends WP_REST_Revisions_Controller {
 		if ( isset( $registered['status'], $request['status'] ) && ! in_array( 'any', $request['status'], true ) ) {
 			$args['post_status'] = $request['status'];
 		} else {
-			$args['post_status'] = wp_list_pluck( get_revision_statuses(), 'name' );
+			$args['post_status'] = get_revision_status_slugs();
 		}
 
 		return $args;

--- a/revisions-extended/includes/revision-list-table.php
+++ b/revisions-extended/includes/revision-list-table.php
@@ -7,6 +7,7 @@ use function RevisionsExtended\Admin\get_updates_subpage_url;
 use function RevisionsExtended\Admin\get_compare_url;
 use function RevisionsExtended\Post_Status\get_revision_statuses;
 use function RevisionsExtended\Post_Status\get_revision_status_slugs;
+use function RevisionsExtended\Post_Status\validate_revision_status;
 use function RevisionsExtended\Revision\get_edit_revision_link;
 use function RevisionsExtended\Revision\get_revisions_by_parent_type;
 
@@ -60,6 +61,7 @@ class Revision_List_Table extends WP_List_Table {
 
 		$orderby   = wp_unslash( filter_input( INPUT_GET, 'orderby' ) );
 		$order     = wp_unslash( filter_input( INPUT_GET, 'order' ) );
+		$status    = wp_unslash( filter_input( INPUT_GET, 'post_status' ) );
 		$search    = wp_unslash( filter_input( INPUT_GET, 's' ) );
 		$parent_id = filter_input( INPUT_GET, 'p', FILTER_VALIDATE_INT );
 
@@ -69,6 +71,10 @@ class Revision_List_Table extends WP_List_Table {
 			'orderby'        => $orderby ?: 'date ID',
 			'order'          => $order ?: 'asc',
 		);
+
+		if ( $status && validate_revision_status( $status ) ) {
+			$query_args['post_status'] = $status;
+		}
 
 		if ( $search ) {
 			$query_args['s'] = $search;
@@ -101,6 +107,7 @@ class Revision_List_Table extends WP_List_Table {
 	protected function get_views() {
 		$view_links = array();
 
+		$current_status    = wp_unslash( filter_input( INPUT_GET, 'post_status' ) );
 		$revision_statuses = get_revision_statuses();
 		$posts_by_status   = (array) wp_count_posts( 'revision' );
 		$total_posts       = array_sum( array_intersect_key( $posts_by_status, $revision_statuses ) );
@@ -120,10 +127,43 @@ class Revision_List_Table extends WP_List_Table {
 		$view_links['all'] = sprintf(
 			'<a href="%1$s"%2$s%3$s>%4$s</a>',
 			esc_url( get_updates_subpage_url( $this->parent_post_type ) ),
-			' class="current"',
-			' aria-current="page"',
+			$current_status ? '' : ' class="current"',
+			$current_status ? '' : ' aria-current="page"',
 			$all_inner_html
 		);
+
+		foreach ( $revision_statuses as $slug => $obj ) {
+			if ( empty( $posts_by_status[ $slug ] ) ) {
+				continue;
+			}
+
+			$inner_html = sprintf(
+				/* translators: 1: Post status. 2: Number of posts. */
+				_nx(
+					'%1$s <span class="count">(%2$s)</span>',
+					'%1$s <span class="count">(%2$s)</span>',
+					$posts_by_status[ $slug ],
+					'posts',
+					'revisions-extended'
+				),
+				esc_html( $obj->label ),
+				number_format_i18n( $posts_by_status[ $slug ] )
+			);
+
+			$view_url = add_query_arg(
+				'post_status',
+				$slug,
+				get_updates_subpage_url( $this->parent_post_type )
+			);
+
+			$view_links[ $slug ] = sprintf(
+				'<a href="%1$s"%2$s%3$s>%4$s</a>',
+				esc_url( $view_url ),
+				$current_status === $slug ? ' class="current"' : '',
+				$current_status === $slug ? ' aria-current="page"' : '',
+				$inner_html
+			);
+		}
 
 		if ( count( $view_links ) > 1 ) {
 			return $view_links;
@@ -204,7 +244,7 @@ class Revision_List_Table extends WP_List_Table {
 	protected function get_sortable_columns() {
 		return array(
 			'title'    => 'title',
-			'status'   => array( 'date', 'asc' ),
+			'status'   => array( 'date title', 'asc' ),
 			'modified' => array( 'modified', true ),
 		);
 	}
@@ -238,7 +278,7 @@ class Revision_List_Table extends WP_List_Table {
 				<span class="screen-reader-text">
 				<?php
 				printf(
-				/* translators: %s: Post title. */
+					/* translators: %s: Post title. */
 					__( '&#8220;%s&#8221; is locked', 'revisions-extended' ),
 					_draft_or_post_title( $post )
 				);
@@ -411,6 +451,13 @@ class Revision_List_Table extends WP_List_Table {
 					get_the_time( __( 'Y/m/d', 'revisions-extended' ), $post ),
 					/* translators: Post time format. See https://www.php.net/manual/datetime.format.php */
 					get_the_time( __( 'g:i a', 'revisions-extended' ), $post )
+				);
+				break;
+			case 'draft':
+			case 'pending':
+				printf(
+					'<strong>%s</strong>',
+					esc_html( $object->label )
 				);
 				break;
 		}

--- a/revisions-extended/includes/revision-list-table.php
+++ b/revisions-extended/includes/revision-list-table.php
@@ -6,6 +6,7 @@ use WP_List_Table, WP_Post, WP_Query;
 use function RevisionsExtended\Admin\get_updates_subpage_url;
 use function RevisionsExtended\Admin\get_compare_url;
 use function RevisionsExtended\Post_Status\get_revision_statuses;
+use function RevisionsExtended\Post_Status\get_revision_status_slugs;
 use function RevisionsExtended\Revision\get_edit_revision_link;
 use function RevisionsExtended\Revision\get_revisions_by_parent_type;
 
@@ -63,7 +64,7 @@ class Revision_List_Table extends WP_List_Table {
 		$parent_id = filter_input( INPUT_GET, 'p', FILTER_VALIDATE_INT );
 
 		$query_args = array(
-			'post_status'    => wp_list_pluck( get_revision_statuses(), 'name' ),
+			'post_status'    => get_revision_status_slugs(),
 			'posts_per_page' => $per_page,
 			'orderby'        => $orderby ?: 'date ID',
 			'order'          => $order ?: 'asc',

--- a/revisions-extended/includes/revision.php
+++ b/revisions-extended/includes/revision.php
@@ -3,7 +3,7 @@
 namespace RevisionsExtended\Revision;
 
 use WP_Error, WP_Post, WP_Post_Type, WP_Query;
-use function RevisionsExtended\Post_Status\get_revision_statuses;
+use function RevisionsExtended\Post_Status\get_revision_status_slugs;
 use function RevisionsExtended\Post_Status\validate_revision_status;
 
 defined( 'WPINC' ) || die();
@@ -316,7 +316,7 @@ function get_edit_revision_link( $revision_id ) {
  * @return string|null
  */
 function filter_pre_wp_unique_post_slug( $override, $slug, $post_ID, $post_status, $post_type ) {
-	$statuses = wp_list_pluck( get_revision_statuses(), 'name' );
+	$statuses = get_revision_status_slugs();
 
 	if ( 'revision' === $post_type && in_array( $post_status, $statuses, true ) ) {
 		$override = $slug;

--- a/revisions-extended/views/revision-compare.php
+++ b/revisions-extended/views/revision-compare.php
@@ -46,6 +46,10 @@ defined( 'WPINC' ) || die();
 				);
 				?>
 			</p>
+		<?php else : ?>
+			<p>
+				<?php echo esc_html( get_post_status_object( $revision->post_status )->label ); ?>
+			</p>
 		<?php endif; ?>
 	<?php endif; ?>
 


### PR DESCRIPTION
This allows updates to be saved without having to specify a future publish date. Add both `draft` and `pending` so that the workflow can be similar to the standard post publishing workflow in Core.