### PR TITLE
Add a notice on the post when we have revisions.

### DIFF
--- a/revisions-extended/src/plugins/editor-modifications/document-settings-panel/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/document-settings-panel/index.js
@@ -56,7 +56,7 @@ const dispatchSingleUpdateNotice = ( typeDisplayName, postId ) => {
  * @param {string} typeDisplayName The singular name of the post type
  * @param {Object} savedPost
  * @param {string} savedPost.type The post type
- * @param {string} savedPost.id The post id
+ * @param {number} savedPost.id The post id
  */
 const dispatchMultipleUpdateNotice = ( typeDisplayName, savedPost ) => {
 	dispatch( GUTENBERG_NOTICE_STORE ).createWarningNotice(

--- a/revisions-extended/src/plugins/editor-modifications/document-settings-panel/index.js
+++ b/revisions-extended/src/plugins/editor-modifications/document-settings-panel/index.js
@@ -44,16 +44,18 @@ const DocumentSettingsPanel = () => {
 				const sortedRevisions = data.sort( revisionSort );
 
 				if ( sortedRevisions.length > 0 ) {
+					const typeDisplayName = getTypeInfo(
+						`${ savedPost.type }.labels.singular_name`
+					).toLowerCase();
+
 					dispatch( 'core/notices' ).createWarningNotice(
 						sprintf(
-							// translators: %s: post type singular name.
+							// translators: %s: post type singular label.
 							__(
 								'This %s has a scheduled update that will replace any changes that you make here.',
 								'revisions-extended'
 							),
-							getTypeInfo(
-								`${ savedPost.type }.labels.singular_name`
-							).toLowerCase()
+							typeDisplayName
 						),
 						{
 							isDismissible: true,
@@ -69,9 +71,13 @@ const DocumentSettingsPanel = () => {
 									url: `${ getAllRevisionUrl(
 										savedPost.type
 									) }&p=${ savedPost.id }`,
-									label: __(
-										'See all updates',
-										'revisions-extended'
+									label: sprintf(
+										// translators: %s: post type singular label.
+										__(
+											'See all updates for this %s',
+											'revisions-extended'
+										),
+										typeDisplayName
 									),
 								},
 							],

--- a/revisions-extended/src/settings.js
+++ b/revisions-extended/src/settings.js
@@ -3,4 +3,5 @@ export const POST_STATUS_PENDING = 'pending';
 export const GUTENBERG_EDITOR_STORE = 'core/editor';
 export const GUTENBERG_EDIT_POST_STORE = 'core/edit-post';
 export const GUTENBERG_INTERFACE_STORE = 'core/interface';
+export const GUTENBERG_NOTICE_STORE = 'core/notices';
 export const WP_PUBLISH_STATUS = 'publish';


### PR DESCRIPTION
This is an attempt to alert the user that there is an update for the post they are editing that will replace their changes should they make any to the `parent` post.

For context: #73, #86.

This PR is the _least amount_ of work possible :). 

**Problem**: If there are 2 updates, it currently links to the one that will be published next based on its expected `publish` date. Should they make changes to that one, the next one in line will replace the changes.

## ScreenShot
![](https://d.pr/i/iyFZWG.png)