### PR TITLE
Turn off the excerpt at the api level.

### DIFF
--- a/revisions-extended/includes/rest-revision-controller.php
+++ b/revisions-extended/includes/rest-revision-controller.php
@@ -325,9 +325,11 @@ class REST_Revision_Controller extends WP_REST_Posts_Controller {
 	public function filter_response_by_context( $post, $context ) {
 
 		if ( ! empty( $post['parent'] ) ) {
-			$parent = get_post( $post['parent'] );
+			$parent_post_type = get_post_type( $post['parent'] );
 
-			if ( ! post_type_supports( $parent->post_type, 'excerpt' ) ) {
+			if ( post_type_supports( $parent_post_type, 'excerpt' ) ) {
+				add_post_type_support( $post['type'], 'excerpt' );
+			} else {
 				remove_post_type_support( $post['type'], 'excerpt' );
 			}
 		}

--- a/revisions-extended/includes/rest-revision-controller.php
+++ b/revisions-extended/includes/rest-revision-controller.php
@@ -318,17 +318,17 @@ class REST_Revision_Controller extends WP_REST_Posts_Controller {
 	 * Gets an array of fields to be included on the response.
 	 *
 	 * @param WP_Post $post Post object.
-	 * @param string $context String representing the context.
+	 * @param string  $context String representing the context.
 	 *
 	 * @return WP_Response Response object
 	 */
 	public function filter_response_by_context( $post, $context ) {
 
-		if( ! empty( $post['parent'] ) ) {
-			$parent  = get_post( $post['parent'] );
+		if ( ! empty( $post['parent'] ) ) {
+			$parent = get_post( $post['parent'] );
 
 			if ( ! post_type_supports( $parent->post_type, 'excerpt' ) ) {
-				remove_post_type_support( $post['type'], 'excerpt');
+				remove_post_type_support( $post['type'], 'excerpt' );
 			}
 		}
 

--- a/revisions-extended/includes/rest-revision-controller.php
+++ b/revisions-extended/includes/rest-revision-controller.php
@@ -315,6 +315,27 @@ class REST_Revision_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
+	 * Gets an array of fields to be included on the response.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @param string $context String representing the context.
+	 *
+	 * @return WP_Response Response object
+	 */
+	public function filter_response_by_context( $post, $context ) {
+
+		if( ! empty( $post['parent'] ) ) {
+			$parent  = get_post( $post['parent'] );
+
+			if ( ! post_type_supports( $parent->post_type, 'excerpt' ) ) {
+				remove_post_type_support( $post['type'], 'excerpt');
+			}
+		}
+
+		return rest_filter_response_by_context( $post, $this->get_item_schema(), $context );
+	}
+
+	/**
 	 * Retrieves the revision's schema, conforming to JSON Schema.
 	 *
 	 * @return array Item schema data.


### PR DESCRIPTION
This is an example PR and an alternative to #108.

Currently, this PR uses the `filter_response_by_context` inherited method to determine if the parent supports the excerpt and turns it off. This is most likely not the best place for this check, as it's not an expected place to change the functionality of the underlying post type but after reading the [documentation](https://developer.wordpress.org/rest-api/extending-the-rest-api/controller-classes/), I wasn't sure what made the most sense. Any ideas?

I think it makes more sense to have this code in the backend because it means that Gutenberg will be responsible for turning it off. It will do a better job upping its priority, limit the 'flash' on load and future proof our code.