### PR TITLE
Add missing param on action

### DIFF
--- a/phpunit/test-rest-revisions-controller.php
+++ b/phpunit/test-rest-revisions-controller.php
@@ -100,7 +100,7 @@ class Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase {
 	 *
 	 * @return void
 	 */
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		wp_set_current_user( 0 );
 	}

--- a/phpunit/test-rest-revisions-controller.php
+++ b/phpunit/test-rest-revisions-controller.php
@@ -381,7 +381,7 @@ class Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase {
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertSame( 13, count( $properties ) );
+		$this->assertSame( 14, count( $properties ) );
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'content', $properties );
 		$this->assertArrayHasKey( 'date', $properties );
@@ -389,6 +389,7 @@ class Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'excerpt', $properties );
 		$this->assertArrayHasKey( 'guid', $properties );
 		$this->assertArrayHasKey( 'id', $properties );
+		$this->assertArrayHasKey( 'meta', $properties );
 		$this->assertArrayHasKey( 'modified', $properties );
 		$this->assertArrayHasKey( 'modified_gmt', $properties );
 		$this->assertArrayHasKey( 'parent', $properties );

--- a/revisions-extended/includes/revision.php
+++ b/revisions-extended/includes/revision.php
@@ -203,10 +203,12 @@ function put_post_revision( $post = null, $autosave = false ) {
 		 * Fires once a revision has been saved.
 		 *
 		 * @since 2.6.0
+		 * @since 6.4.0 The post_id parameter was added.
 		 *
 		 * @param int $revision_id Post revision ID.
+   		 * @param int $post_id     Post ID.
 		 */
-		do_action( '_wp_put_post_revision', $revision_id );
+		do_action( '_wp_put_post_revision', $revision_id, $post['post_parent'] );
 	}
 
 	return $revision_id;

--- a/revisions-extended/includes/revision.php
+++ b/revisions-extended/includes/revision.php
@@ -206,7 +206,7 @@ function put_post_revision( $post = null, $autosave = false ) {
 		 * @since 6.4.0 The post_id parameter was added.
 		 *
 		 * @param int $revision_id Post revision ID.
-   		 * @param int $post_id     Post ID.
+		 * @param int $post_id     Post ID.
 		 */
 		do_action( '_wp_put_post_revision', $revision_id, $post['post_parent'] );
 	}


### PR DESCRIPTION
Add additional param added in 6.4.0.

Follows same structure as https://github.com/WordPress/wordpress-develop/blob/6.4/src/wp-includes/revision.php#L385-L396